### PR TITLE
fix(excerpt): preserve inline code content instead of stripping it entirely

### DIFF
--- a/src/lib/markdown.ts
+++ b/src/lib/markdown.ts
@@ -98,7 +98,7 @@ export function generateExcerpt(content: string): string {
   plain = plain.replace(/!\[[^\]]*\]\([^)]+\)/g, '');
   plain = plain.replace(/\*\[([^\]]+)\*\]\([^)]+\)/g, '$1');
   plain = plain.replace(/(\$\*\*|__|\*|_)/g, '');
-  plain = plain.replace(/`[^`]*`/g, '');
+  plain = plain.replace(/`([^`]+)`/g, '$1');
   plain = plain.replace(/^>\s+/gm, '');
   plain = plain.replace(/\s+/g, ' ').trim();
   


### PR DESCRIPTION
FIX #14 
Previously, inline code blocks (`...`) were removed completely, which caused text like `<rehype-raw>`, `<iframe>`, and `<video>` to disappear from generated excerpts.

Now we strip only the backticks while keeping the inner content, ensuring technical tag references remain visible in summaries.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed excerpt generation to properly preserve inline code content. Previously, inline code snippets were being completely removed from excerpts. Now, code content is retained and displays correctly in generated previews and summaries, improving readability and completeness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->