### PR TITLE
feat: add docutils-backed rendering for rST series

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,8 @@
 # misc
 .DS_Store
 *.pem
+__pycache__/
+*.py[cod]
 
 # debug
 npm-debug.log*

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@
 *.pem
 __pycache__/
 *.py[cod]
+.venv-rst/
 
 # debug
 npm-debug.log*

--- a/TODO.md
+++ b/TODO.md
@@ -22,6 +22,15 @@
 - [ ] **Link Validator**: Script to check for broken internal wiki-links and external URLs.
 - [ ] **Content Porter**: Tool to import/export notes from Obsidian or Notion.
 - [ ] **Optimization**: Automatically compress and resize co-located images during build.
+- [ ] **Build Performance**: Profile `build:dev`, clean stale export/search outputs before indexing, and consider a lighter local build path that skips expensive full-site indexing when not needed.
+
+## 📚 rST Follow-up
+- [ ] **Fixture Coverage**: Add more compatibility fixtures from legacy rST series, including nested lists, tables, directives, images, and internal links.
+- [ ] **Parser Diagnostics**: Improve rST build errors with clearer file context, line numbers where possible, and actionable unsupported-syntax messages.
+- [ ] **Syntax Contract**: Document the exact supported rST subset and explicitly list unsupported or partial constructs.
+- [ ] **Asset & Link Handling**: Harden relative asset resolution and add validation for broken local rST links and image references.
+- [ ] **Reading Time**: Reuse the shared mixed-CJK reading-time rules for rST content so Chinese, Japanese, and Korean text are counted consistently.
+- [ ] **Advanced Constructs**: Evaluate the highest-value next rST features from real imported content, such as footnotes, simple tables, and selected directives.
 
 ## ✅ Completed Highlights
 - [x] **JSON-LD Structured Data**: `BlogPosting`, `Book`, and `Article` schemas for Google rich results.
@@ -33,3 +42,4 @@
 - [x] **Robust Engineering**: Zero hydration mismatches, Zod validation, and 64+ automated tests.
 - [x] **Refined UI**: High-contrast typography, four color palettes, and horizontal scroll featured sections.
 - [x] **Sub-features**: Newsletter/Subscribe page, Reading Progress, and Author Ecosystem.
+- [x] **Series-scoped rST Support**: Strict rST series detection, README-based indexes, Unicode-safe static params, and legacy redirect handling.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -16,6 +16,8 @@ const eslintConfig = defineConfig([
     "public/pagefind/**",
     // Package compiled output — not authored code
     "packages/*/dist/**",
+    // Local Python renderer virtualenv
+    ".venv-rst/**",
   ]),
 ]);
 

--- a/scripts/render-rst.py
+++ b/scripts/render-rst.py
@@ -198,6 +198,20 @@ def extract_headings(document: Any) -> list[dict[str, Any]]:
     return headings
 
 
+def extract_body_text(document: Any) -> str:
+    from docutils import nodes
+
+    body_parts: list[str] = []
+    for child in document.children:
+        if isinstance(child, (nodes.docinfo, nodes.field_list, nodes.comment, nodes.title)):
+            continue
+        text = child.astext().strip()
+        if text:
+            body_parts.append(text)
+
+    return "\n\n".join(body_parts).strip()
+
+
 def build_output(document: Any, source: str, source_file: Path, image_base_slug: str) -> dict[str, Any]:
     from docutils import nodes
     from docutils.core import publish_parts
@@ -224,7 +238,7 @@ def build_output(document: Any, source: str, source_file: Path, image_base_slug:
     return {
         "title": title_node.astext().strip(),
         "html": rewrite_html_assets(html_body, assets),
-        "text": document.astext().strip(),
+        "text": extract_body_text(document),
         "headings": extract_headings(document),
         "metadata": extract_metadata(document),
         "assets": assets,

--- a/scripts/render-rst.py
+++ b/scripts/render-rst.py
@@ -1,8 +1,10 @@
 #!/usr/bin/env python3
 
 import argparse
+import html
 import json
 import posixpath
+import re
 import sys
 from pathlib import Path
 from typing import Any
@@ -153,6 +155,23 @@ def extract_assets(document: Any, source_file: Path, image_base_slug: str) -> li
     return assets
 
 
+def rewrite_html_assets(rendered_html: str, assets: list[dict[str, Any]]) -> str:
+    rewritten = rendered_html
+
+    for asset in assets:
+        original = asset["original"]
+        resolved = asset["resolved"]
+        escaped_original = re.escape(html.escape(original, quote=True))
+
+        rewritten = re.sub(
+            rf'(\s(?:src|href)=["\']){escaped_original}(["\'])',
+            rf'\1{html.escape(resolved, quote=True)}\2',
+            rewritten,
+        )
+
+    return rewritten
+
+
 def extract_headings(document: Any) -> list[dict[str, Any]]:
     from docutils import nodes
 
@@ -199,13 +218,16 @@ def build_output(document: Any, source: str, source_file: Path, image_base_slug:
         },
     )
 
+    assets = extract_assets(document, source_file, image_base_slug)
+    html_body = parts.get("html_body", "").strip() or parts.get("fragment", "").strip()
+
     return {
         "title": title_node.astext().strip(),
-        "html": parts.get("html_body", "").strip() or parts.get("fragment", "").strip(),
+        "html": rewrite_html_assets(html_body, assets),
         "text": document.astext().strip(),
         "headings": extract_headings(document),
         "metadata": extract_metadata(document),
-        "assets": extract_assets(document, source_file, image_base_slug),
+        "assets": assets,
         "warnings": [],
     }
 

--- a/scripts/render-rst.py
+++ b/scripts/render-rst.py
@@ -183,7 +183,7 @@ def register_passthrough_roles(warnings: list[str]) -> None:
         if refid is not None:
             return [nodes.reference(rawtext, display_text, refuri=f"#{refid}", classes=["numref"])], []
 
-        warnings.append(f'Unsupported interpreted text role ":numref:" rendered as plain inline text.')
+        warnings.append('Unsupported interpreted text role ":numref:" rendered as plain inline text.')
         return [nodes.inline(rawtext, display_text, classes=["numref"])], []
 
     for role_name in ("dtag",):
@@ -424,6 +424,8 @@ def build_output(document: Any, source: str, source_file: Path, image_base_slug:
             "initial_header_level": 2,
             "report_level": 2,
             "halt_level": 5,
+            "file_insertion_enabled": False,
+            "raw_enabled": False,
         },
     )
 

--- a/scripts/render-rst.py
+++ b/scripts/render-rst.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import argparse
+import copy
 import html
 import json
 import posixpath
@@ -108,6 +109,29 @@ def register_doc_role(source_file: Path, warnings: list[str]) -> None:
         return [nodes.reference(rawtext, display_text, refuri=refuri)], []
 
     roles.register_canonical_role("doc", doc_role)
+
+
+def register_passthrough_roles(warnings: list[str]) -> None:
+    from docutils import nodes
+    from docutils.parsers.rst import roles
+
+    def make_passthrough_role(role_name: str):
+        def passthrough_role(  # type: ignore[override]
+            _name: str,
+            rawtext: str,
+            text: str,
+            _lineno: int,
+            _inliner: Any,
+            _options: dict[str, Any] | None = None,
+            _content: list[str] | None = None,
+        ) -> tuple[list[Any], list[Any]]:
+            warnings.append(f'Unsupported interpreted text role ":{role_name}:" rendered as plain inline text.')
+            return [nodes.inline(rawtext, text, classes=[role_name])], []
+
+        return passthrough_role
+
+    for role_name in ("dtag",):
+        roles.register_canonical_role(role_name, make_passthrough_role(role_name))
 
 
 def parse_args() -> argparse.Namespace:
@@ -281,9 +305,27 @@ def extract_headings(document: Any) -> list[dict[str, Any]]:
 def extract_body_text(document: Any) -> str:
     from docutils import nodes
 
+    body_tree = copy.deepcopy(document)
+    for node in list(body_tree.findall(nodes.system_message)):
+        parent = node.parent
+        if parent is not None:
+            parent.remove(node)
+
+    for node in list(body_tree.findall(nodes.footnote)):
+        parent = node.parent
+        if parent is not None:
+            parent.remove(node)
+
+    for node in list(body_tree.findall(nodes.footnote_reference)):
+        parent = node.parent
+        if parent is not None:
+            parent.remove(node)
+
     body_parts: list[str] = []
-    for child in document.children:
-        if isinstance(child, (nodes.docinfo, nodes.field_list, nodes.comment, nodes.title, nodes.system_message)):
+    for child in body_tree.children:
+        if isinstance(child, (nodes.docinfo, nodes.field_list, nodes.comment, nodes.title, nodes.system_message, nodes.footnote)):
+            continue
+        if child.tagname == "footnote_list":
             continue
         text = child.astext().strip()
         if text:
@@ -357,6 +399,7 @@ def main() -> int:
     try:
         warnings: list[str] = []
         register_doc_role(source_file, warnings)
+        register_passthrough_roles(warnings)
         source = source_file.read_text(encoding="utf-8")
         document = publish_doctree(
             source=source,

--- a/scripts/render-rst.py
+++ b/scripts/render-rst.py
@@ -243,6 +243,12 @@ def extract_metadata(document: Any) -> dict[str, Any]:
                 if isinstance(entry, nodes.author):
                     metadata["author"] = entry.astext().strip()
                     continue
+                if isinstance(entry, nodes.field) and len(entry.children) >= 2:
+                    name = entry.children[0].astext().strip()
+                    value = entry.children[1].astext().strip()
+                    if name and value:
+                        metadata[name] = normalize_metadata_value(name, value)
+                    continue
 
                 key = entry.tagname.lower()
                 value = entry.astext().strip()

--- a/scripts/render-rst.py
+++ b/scripts/render-rst.py
@@ -115,6 +115,19 @@ def register_passthrough_roles(warnings: list[str]) -> None:
     from docutils import nodes
     from docutils.parsers.rst import roles
 
+    def parse_role_target(text: str) -> tuple[str | None, str]:
+        target = text.strip()
+        match = re.match(r"(.+?)\s*<(.+)>$", target)
+        if match:
+            return match.group(1).strip(), match.group(2).strip()
+        return None, target
+
+    def normalize_internal_ref(target: str) -> str:
+        cleaned = target.strip().strip("`")
+        cleaned = cleaned.replace("_", "-")
+        cleaned = re.sub(r"\s+", "-", cleaned)
+        return cleaned
+
     def make_passthrough_role(role_name: str):
         def passthrough_role(  # type: ignore[override]
             _name: str,
@@ -130,8 +143,38 @@ def register_passthrough_roles(warnings: list[str]) -> None:
 
         return passthrough_role
 
+    def ref_role(  # type: ignore[override]
+        _name: str,
+        rawtext: str,
+        text: str,
+        _lineno: int,
+        _inliner: Any,
+        _options: dict[str, Any] | None = None,
+        _content: list[str] | None = None,
+    ) -> tuple[list[Any], list[Any]]:
+        label, target = parse_role_target(text)
+        display_text = label or target
+        refid = normalize_internal_ref(target)
+        return [nodes.reference(rawtext, display_text, refuri=f"#{refid}")], []
+
+    def numref_role(  # type: ignore[override]
+        _name: str,
+        rawtext: str,
+        text: str,
+        _lineno: int,
+        _inliner: Any,
+        _options: dict[str, Any] | None = None,
+        _content: list[str] | None = None,
+    ) -> tuple[list[Any], list[Any]]:
+        label, target = parse_role_target(text)
+        display_text = target if label and "%s" in label else (label or target)
+        warnings.append(f'Unsupported interpreted text role ":numref:" rendered as plain inline text.')
+        return [nodes.inline(rawtext, display_text, classes=["numref"])], []
+
     for role_name in ("dtag",):
         roles.register_canonical_role(role_name, make_passthrough_role(role_name))
+    roles.register_canonical_role("ref", ref_role)
+    roles.register_canonical_role("numref", numref_role)
 
 
 def parse_args() -> argparse.Namespace:

--- a/scripts/render-rst.py
+++ b/scripts/render-rst.py
@@ -128,6 +128,17 @@ def register_passthrough_roles(warnings: list[str]) -> None:
         cleaned = re.sub(r"\s+", "-", cleaned)
         return cleaned
 
+    def resolve_named_refid(inliner: Any, target: str) -> str | None:
+        document = getattr(inliner, "document", None)
+        if document is None:
+            return None
+
+        nameids = getattr(document, "nameids", {})
+        refid = nameids.get(target)
+        if isinstance(refid, str) and refid:
+            return refid
+        return None
+
     def make_passthrough_role(role_name: str):
         def passthrough_role(  # type: ignore[override]
             _name: str,
@@ -154,7 +165,7 @@ def register_passthrough_roles(warnings: list[str]) -> None:
     ) -> tuple[list[Any], list[Any]]:
         label, target = parse_role_target(text)
         display_text = label or target
-        refid = normalize_internal_ref(target)
+        refid = resolve_named_refid(_inliner, target) or normalize_internal_ref(target)
         return [nodes.reference(rawtext, display_text, refuri=f"#{refid}")], []
 
     def numref_role(  # type: ignore[override]
@@ -168,6 +179,10 @@ def register_passthrough_roles(warnings: list[str]) -> None:
     ) -> tuple[list[Any], list[Any]]:
         label, target = parse_role_target(text)
         display_text = target if label and "%s" in label else (label or target)
+        refid = resolve_named_refid(_inliner, target)
+        if refid is not None:
+            return [nodes.reference(rawtext, display_text, refuri=f"#{refid}", classes=["numref"])], []
+
         warnings.append(f'Unsupported interpreted text role ":numref:" rendered as plain inline text.')
         return [nodes.inline(rawtext, display_text, classes=["numref"])], []
 

--- a/scripts/render-rst.py
+++ b/scripts/render-rst.py
@@ -492,9 +492,11 @@ def main() -> int:
     except RstRenderError as exc:
         print(str(exc), file=sys.stderr)
         return 1
-    except Exception as exc:
+    except (OSError, ValueError, KeyError, AttributeError) as exc:
         print(f"Failed to render {source_file}: {exc}", file=sys.stderr)
         return 1
+    except Exception:
+        raise
 
 
 if __name__ == "__main__":

--- a/scripts/render-rst.py
+++ b/scripts/render-rst.py
@@ -1,0 +1,264 @@
+#!/usr/bin/env python3
+
+import argparse
+import json
+import posixpath
+import sys
+from pathlib import Path
+from typing import Any
+
+
+CSV_FIELDS = {"tags", "authors", "posts", "redirectfrom"}
+BOOLEAN_FIELDS = {"featured", "pinned", "draft", "latex", "toc", "commentable"}
+SCALAR_FIELDS = {
+    "date",
+    "subtitle",
+    "excerpt",
+    "category",
+    "author",
+    "layout",
+    "series",
+    "coverimage",
+    "sort",
+    "type",
+}
+
+
+class RstRenderError(Exception):
+    pass
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Render a single rST file to JSON via docutils.")
+    parser.add_argument("--file", required=True, help="Absolute or relative path to the .rst file")
+    parser.add_argument(
+        "--image-base-slug",
+        required=True,
+        help="Public-relative base slug for local assets, for example posts/my-post",
+    )
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="Fail on missing local assets instead of reporting them in the output",
+    )
+    return parser.parse_args()
+
+
+def normalize_metadata_value(key: str, value: str) -> Any:
+    lowered = key.lower()
+    stripped = value.strip()
+
+    if lowered in CSV_FIELDS:
+        return [part.strip() for part in stripped.split(",") if part.strip()]
+
+    if lowered in BOOLEAN_FIELDS:
+        normalized = stripped.lower()
+        if normalized == "true":
+            return True
+        if normalized == "false":
+            return False
+        raise RstRenderError(f'Invalid boolean for "{key}": {value}')
+
+    if lowered in SCALAR_FIELDS:
+        return stripped
+
+    return stripped
+
+
+def extract_metadata(document: Any) -> dict[str, Any]:
+    from docutils import nodes
+
+    metadata: dict[str, Any] = {}
+
+    for child in document.children:
+        if isinstance(child, nodes.docinfo):
+            for entry in child.children:
+                if isinstance(entry, nodes.authors):
+                    metadata["authors"] = [author.astext().strip() for author in entry.children if author.astext().strip()]
+                    continue
+                if isinstance(entry, nodes.author):
+                    metadata["author"] = entry.astext().strip()
+                    continue
+
+                key = entry.tagname.lower()
+                value = entry.astext().strip()
+                if value:
+                    metadata[key] = normalize_metadata_value(key, value)
+            continue
+
+        if isinstance(child, nodes.field_list):
+            for field in child.children:
+                if not isinstance(field, nodes.field):
+                    continue
+                name = field.children[0].astext().strip()
+                value = field.children[1].astext().strip()
+                if not name or not value:
+                    continue
+                metadata[name] = normalize_metadata_value(name, value)
+            continue
+
+        if isinstance(child, nodes.title):
+            continue
+
+        break
+
+    if "author" in metadata and "authors" not in metadata:
+        metadata["authors"] = [metadata["author"]]
+
+    normalized: dict[str, Any] = {}
+    for key, value in metadata.items():
+        lowered = key.lower()
+        if lowered == "coverimage":
+            normalized["coverImage"] = value
+        elif lowered == "redirectfrom":
+            normalized["redirectFrom"] = value
+        else:
+            normalized[lowered] = value
+
+    return normalized
+
+
+def resolve_asset_uri(uri: str, source_file: Path, image_base_slug: str) -> tuple[str, bool]:
+    stripped = uri.strip()
+    if not stripped:
+        return stripped, False
+
+    if stripped.startswith(("http://", "https://", "data:", "mailto:", "#", "/")):
+        return stripped, True
+
+    candidate = (source_file.parent / stripped).resolve()
+    exists = candidate.exists()
+
+    normalized_base = image_base_slug.strip("/")
+    relative_uri = stripped.replace("\\", "/")
+    resolved = "/" + posixpath.normpath(posixpath.join(normalized_base, relative_uri)).lstrip("/")
+    return resolved, exists
+
+
+def extract_assets(document: Any, source_file: Path, image_base_slug: str) -> list[dict[str, Any]]:
+    from docutils import nodes
+
+    assets: list[dict[str, Any]] = []
+    for image in document.findall(nodes.image):
+        original = image.get("uri", "").strip()
+        if not original:
+            continue
+        resolved, exists = resolve_asset_uri(original, source_file, image_base_slug)
+        assets.append({
+            "original": original,
+            "resolved": resolved,
+            "exists": exists,
+        })
+
+    return assets
+
+
+def extract_headings(document: Any) -> list[dict[str, Any]]:
+    from docutils import nodes
+
+    headings: list[dict[str, Any]] = []
+    for section in document.findall(nodes.section):
+        title = next((child for child in section.children if isinstance(child, nodes.title)), None)
+        if title is None:
+            continue
+
+        ids = section.get("ids", [])
+        depth = 0
+        parent = section.parent
+        while parent is not None:
+            if isinstance(parent, nodes.section):
+                depth += 1
+            parent = parent.parent
+
+        headings.append({
+            "id": ids[0] if ids else "",
+            "text": title.astext().strip(),
+            "level": depth + 2,
+        })
+
+    return headings
+
+
+def build_output(document: Any, source: str, source_file: Path, image_base_slug: str) -> dict[str, Any]:
+    from docutils import nodes
+    from docutils.core import publish_parts
+
+    title_node = next(document.findall(nodes.title), None)
+    if title_node is None:
+        raise RstRenderError("Missing document title.")
+
+    parts = publish_parts(
+        source=source,
+        writer_name="html5",
+        settings_overrides={
+            "embed_stylesheet": False,
+            "stylesheet_path": None,
+            "initial_header_level": 2,
+            "report_level": 2,
+            "halt_level": 5,
+        },
+    )
+
+    return {
+        "title": title_node.astext().strip(),
+        "html": parts.get("html_body", "").strip() or parts.get("fragment", "").strip(),
+        "text": document.astext().strip(),
+        "headings": extract_headings(document),
+        "metadata": extract_metadata(document),
+        "assets": extract_assets(document, source_file, image_base_slug),
+        "warnings": [],
+    }
+
+
+def main() -> int:
+    args = parse_args()
+    source_file = Path(args.file).expanduser()
+    if not source_file.is_absolute():
+        source_file = (Path.cwd() / source_file).resolve()
+
+    if not source_file.exists():
+        print(f"rST file not found: {source_file}", file=sys.stderr)
+        return 1
+
+    try:
+        from docutils.core import publish_doctree
+    except ImportError:
+        print(
+            "Missing Python dependency: docutils. Install it with `python3 -m pip install docutils`.",
+            file=sys.stderr,
+        )
+        return 1
+
+    try:
+        source = source_file.read_text(encoding="utf-8")
+        document = publish_doctree(
+            source=source,
+            settings_overrides={
+                "report_level": 2,
+                "halt_level": 5,
+                "file_insertion_enabled": False,
+                "raw_enabled": False,
+            },
+        )
+        output = build_output(document, source, source_file, args.image_base_slug)
+
+        if args.strict:
+            missing = [asset for asset in output["assets"] if not asset["exists"]]
+            if missing:
+                first = missing[0]
+                raise RstRenderError(
+                    f'Missing local asset "{first["original"]}" in {source_file}'
+                )
+
+        print(json.dumps(output, ensure_ascii=False))
+        return 0
+    except RstRenderError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+    except Exception as exc:
+        print(f"Failed to render {source_file}: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/render-rst.py
+++ b/scripts/render-rst.py
@@ -30,6 +30,86 @@ class RstRenderError(Exception):
     pass
 
 
+def detect_series_root(source_file: Path) -> Path | None:
+    parts = source_file.resolve().parts
+    try:
+        series_index = parts.index("series")
+    except ValueError:
+        return None
+
+    if series_index + 1 >= len(parts):
+        return None
+
+    return Path(*parts[: series_index + 2])
+
+
+def slug_from_doc_path(doc_path: Path) -> str:
+    if doc_path.name in {"index.rst", "README.rst"}:
+        return doc_path.parent.name
+    return doc_path.stem
+
+
+def resolve_doc_target_path(source_file: Path, target: str) -> Path | None:
+    candidate_base = (source_file.parent / target).resolve()
+    candidate_paths = [
+        candidate_base.with_suffix(".rst"),
+        candidate_base / "index.rst",
+        candidate_base / "README.rst",
+    ]
+
+    for candidate in candidate_paths:
+        if candidate.exists():
+            return candidate
+
+    return None
+
+
+def resolve_doc_target_uri(source_file: Path, target: str) -> str | None:
+    target_path = resolve_doc_target_path(source_file, target)
+    if target_path is None:
+        return None
+
+    series_root = detect_series_root(target_path)
+    if series_root is None:
+        return None
+
+    series_slug = series_root.name
+    slug = slug_from_doc_path(target_path)
+    return f"/{series_slug}/{slug}"
+
+
+def register_doc_role(source_file: Path, warnings: list[str]) -> None:
+    from docutils import nodes
+    from docutils.parsers.rst import roles
+
+    def doc_role(  # type: ignore[override]
+        _name: str,
+        rawtext: str,
+        text: str,
+        _lineno: int,
+        _inliner: Any,
+        _options: dict[str, Any] | None = None,
+        _content: list[str] | None = None,
+    ) -> tuple[list[Any], list[Any]]:
+        label = None
+        target = text.strip()
+        match = re.match(r"(.+?)\s*<(.+)>$", target)
+        if match:
+            label = match.group(1).strip()
+            target = match.group(2).strip()
+
+        refuri = resolve_doc_target_uri(source_file, target)
+        if refuri is None:
+            warnings.append(f'Unresolved :doc: target "{target}" in {source_file}')
+            display_text = label or target.split("/")[-1]
+            return [nodes.literal(rawtext, display_text)], []
+
+        display_text = label or target.split("/")[-1]
+        return [nodes.reference(rawtext, display_text, refuri=refuri)], []
+
+    roles.register_canonical_role("doc", doc_role)
+
+
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Render a single rST file to JSON via docutils.")
     parser.add_argument("--file", required=True, help="Absolute or relative path to the .rst file")
@@ -203,7 +283,7 @@ def extract_body_text(document: Any) -> str:
 
     body_parts: list[str] = []
     for child in document.children:
-        if isinstance(child, (nodes.docinfo, nodes.field_list, nodes.comment, nodes.title)):
+        if isinstance(child, (nodes.docinfo, nodes.field_list, nodes.comment, nodes.title, nodes.system_message)):
             continue
         text = child.astext().strip()
         if text:
@@ -212,7 +292,16 @@ def extract_body_text(document: Any) -> str:
     return "\n\n".join(body_parts).strip()
 
 
-def build_output(document: Any, source: str, source_file: Path, image_base_slug: str) -> dict[str, Any]:
+def remove_system_messages(document: Any) -> None:
+    from docutils import nodes
+
+    for node in list(document.findall(nodes.system_message)):
+        parent = node.parent
+        if parent is not None:
+            parent.remove(node)
+
+
+def build_output(document: Any, source: str, source_file: Path, image_base_slug: str, warnings: list[str]) -> dict[str, Any]:
     from docutils import nodes
     from docutils.core import publish_parts
 
@@ -242,7 +331,7 @@ def build_output(document: Any, source: str, source_file: Path, image_base_slug:
         "headings": extract_headings(document),
         "metadata": extract_metadata(document),
         "assets": assets,
-        "warnings": [],
+        "warnings": list(dict.fromkeys(warnings)),
     }
 
 
@@ -266,6 +355,8 @@ def main() -> int:
         return 1
 
     try:
+        warnings: list[str] = []
+        register_doc_role(source_file, warnings)
         source = source_file.read_text(encoding="utf-8")
         document = publish_doctree(
             source=source,
@@ -276,7 +367,8 @@ def main() -> int:
                 "raw_enabled": False,
             },
         )
-        output = build_output(document, source, source_file, args.image_base_slug)
+        remove_system_messages(document)
+        output = build_output(document, source, source_file, args.image_base_slug, warnings)
 
         if args.strict:
             missing = [asset for asset in output["assets"] if not asset["exists"]]

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -518,6 +518,11 @@ body {
   color: var(--accent);
 }
 
+.rst-rendered .numref {
+  color: var(--accent);
+  font-weight: 600;
+}
+
 .rst-rendered pre.literal-block,
 .rst-rendered pre.code.literal-block {
   overflow-x: auto;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -451,3 +451,58 @@ body {
 [id] {
   scroll-margin-top: 5rem;
 }
+
+.rst-rendered figure {
+  margin: 2rem 0;
+}
+
+.rst-rendered figure > img {
+  display: block;
+  width: 100%;
+  height: auto;
+  border-radius: 0.75rem;
+}
+
+.rst-rendered figcaption {
+  margin-top: 0.75rem;
+  text-align: center;
+  font-size: 0.95rem;
+  line-height: 1.6;
+  color: var(--muted);
+  font-style: italic;
+}
+
+.rst-rendered aside.admonition {
+  margin: 2rem 0;
+  border-left: 4px solid var(--accent);
+  border-radius: 0.75rem;
+  padding: 1rem 1.25rem;
+  background: color-mix(in srgb, var(--accent) 8%, var(--background));
+}
+
+.rst-rendered aside.admonition > :first-child {
+  margin-top: 0;
+}
+
+.rst-rendered aside.admonition > :last-child {
+  margin-bottom: 0;
+}
+
+.rst-rendered .admonition-title {
+  margin-bottom: 0.5rem;
+  font-family: var(--font-inter), ui-sans-serif, system-ui, sans-serif;
+  font-size: 0.8rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--heading);
+}
+
+.rst-rendered .docutils.literal {
+  border: 1px solid color-mix(in srgb, var(--muted) 24%, transparent);
+  border-radius: 0.375rem;
+  background: color-mix(in srgb, var(--muted) 10%, var(--background));
+  padding: 0.1rem 0.35rem;
+  font-size: 0.9em;
+  color: var(--heading);
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -506,3 +506,30 @@ body {
   font-size: 0.9em;
   color: var(--heading);
 }
+
+.rst-rendered pre.literal-block,
+.rst-rendered pre.code.literal-block {
+  overflow-x: auto;
+  border: 1px solid color-mix(in srgb, var(--muted) 18%, transparent);
+  border-radius: 0.875rem;
+  background: color-mix(in srgb, var(--foreground) 4%, var(--background));
+  padding: 1rem 1.25rem;
+}
+
+.rst-rendered pre.code.literal-block code {
+  border: 0;
+  background: transparent;
+  padding: 0;
+  color: inherit;
+}
+
+.rst-rendered pre.code.literal-block .keyword,
+.rst-rendered pre.code.literal-block .name.function {
+  color: var(--accent);
+  font-weight: 600;
+}
+
+.rst-rendered pre.code.literal-block .literal.string,
+.rst-rendered pre.code.literal-block .literal.string.double {
+  color: color-mix(in srgb, var(--accent) 68%, var(--foreground));
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -523,6 +523,13 @@ body {
   font-weight: 600;
 }
 
+.rst-rendered math {
+  display: inline-block;
+  max-width: 100%;
+  overflow-x: auto;
+  vertical-align: middle;
+}
+
 .rst-rendered pre.literal-block,
 .rst-rendered pre.code.literal-block {
   overflow-x: auto;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -507,6 +507,17 @@ body {
   color: var(--heading);
 }
 
+.rst-rendered .dtag {
+  display: inline-block;
+  border: 1px solid color-mix(in srgb, var(--accent) 28%, transparent);
+  border-radius: 999px;
+  background: color-mix(in srgb, var(--accent) 10%, var(--background));
+  padding: 0.1rem 0.55rem;
+  font-size: 0.78rem;
+  font-weight: 600;
+  color: var(--accent);
+}
+
 .rst-rendered pre.literal-block,
 .rst-rendered pre.code.literal-block {
   overflow-x: auto;
@@ -532,4 +543,27 @@ body {
 .rst-rendered pre.code.literal-block .literal.string,
 .rst-rendered pre.code.literal-block .literal.string.double {
   color: color-mix(in srgb, var(--accent) 68%, var(--foreground));
+}
+
+.rst-rendered a[role="doc-noteref"] {
+  font-size: 0.82em;
+  vertical-align: super;
+}
+
+.rst-rendered .footnote-list {
+  margin: 1.5rem 0 2rem;
+  border-top: 1px solid color-mix(in srgb, var(--muted) 24%, transparent);
+  padding-top: 1rem;
+}
+
+.rst-rendered .footnote {
+  margin: 0.75rem 0;
+  color: var(--muted);
+  font-size: 0.95rem;
+}
+
+.rst-rendered .footnote .label {
+  margin-right: 0.4rem;
+  font-weight: 600;
+  color: var(--heading);
 }

--- a/src/components/RstRenderer.test.tsx
+++ b/src/components/RstRenderer.test.tsx
@@ -11,6 +11,7 @@ describe('RstRenderer', () => {
       />
     );
 
+    expect(html).toContain('rst-rendered');
     expect(html).toContain('id="intro"');
     expect(html).toContain('/posts/demo/test.png');
     expect(html).not.toContain('alert(1)');

--- a/src/components/RstRenderer.test.tsx
+++ b/src/components/RstRenderer.test.tsx
@@ -3,6 +3,20 @@ import { renderToStaticMarkup } from 'react-dom/server';
 import RstRenderer from './RstRenderer';
 
 describe('RstRenderer', () => {
+  test('renders pre-rendered html when available', () => {
+    const html = renderToStaticMarkup(
+      <RstRenderer
+        content="Fallback body"
+        html={'<section><h2 id="intro">Intro</h2><p><img src="/posts/demo/test.png" alt="Test" /></p><script>alert(1)</script></section>'}
+      />
+    );
+
+    expect(html).toContain('id="intro"');
+    expect(html).toContain('/posts/demo/test.png');
+    expect(html).not.toContain('alert(1)');
+    expect(html).not.toContain('<script');
+  });
+
   test('renders converted headings, links, and code blocks through the markdown renderer', () => {
     const html = renderToStaticMarkup(
       <RstRenderer

--- a/src/components/RstRenderer.test.tsx
+++ b/src/components/RstRenderer.test.tsx
@@ -7,7 +7,7 @@ describe('RstRenderer', () => {
     const html = renderToStaticMarkup(
       <RstRenderer
         content="Fallback body"
-        html={'<section><h2 id="intro">Intro</h2><p><img src="/posts/demo/test.png" alt="Test" /></p><script>alert(1)</script></section>'}
+        html={'<section><h2 id="intro">Intro</h2><p><img src="/posts/demo/test.png" alt="Test" onerror="alert(2)" /></p><a href="/demo" onclick="alert(3)">Link</a><script>alert(1)</script></section>'}
       />
     );
 
@@ -16,6 +16,8 @@ describe('RstRenderer', () => {
     expect(html).toContain('/posts/demo/test.png');
     expect(html).not.toContain('alert(1)');
     expect(html).not.toContain('<script');
+    expect(html).not.toContain('onclick');
+    expect(html).not.toContain('onerror');
   });
 
   test('renders converted headings, links, and code blocks through the markdown renderer', () => {

--- a/src/components/RstRenderer.tsx
+++ b/src/components/RstRenderer.tsx
@@ -1,15 +1,47 @@
 import MarkdownRenderer from '@/components/MarkdownRenderer';
+import KatexStyles from '@/components/KatexStyles';
 import type { SlugRegistryEntry } from '@/lib/markdown';
 import { rstToMarkdown } from '@/lib/rst';
 
 interface RstRendererProps {
   content: string;
+  html?: string;
   latex?: boolean;
   slug?: string;
   slugRegistry?: Map<string, SlugRegistryEntry>;
 }
 
-export default function RstRenderer({ content, latex = false, slug, slugRegistry }: RstRendererProps) {
+const proseClasses = `prose prose-lg max-w-none min-w-0 overflow-x-hidden text-foreground
+      prose-headings:font-serif prose-headings:text-heading
+      prose-p:text-foreground prose-p:leading-loose
+      prose-strong:text-heading prose-strong:font-semibold
+      prose-code:bg-muted/15 prose-code:px-1.5 prose-code:py-0.5 prose-code:rounded-md prose-code:border prose-code:border-muted/20 prose-code:text-[0.9em] prose-code:font-medium
+      prose-code:before:content-none prose-code:after:content-none
+      prose-blockquote:italic
+      prose-th:text-heading prose-td:text-foreground
+      dark:prose-invert`;
+
+function sanitizeRenderedHtml(html: string): string {
+  return html
+    .replace(/<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi, '')
+    .replace(/\son[a-z]+\s*=\s*(?:"[^"]*"|'[^']*'|[^\s>]+)/gi, '');
+}
+
+export default function RstRenderer({ content, html, latex = false, slug, slugRegistry }: RstRendererProps) {
+  if (html) {
+    return (
+      <>
+        {latex && <KatexStyles />}
+        <div className="bg-background">
+          <div
+            className={proseClasses}
+            dangerouslySetInnerHTML={{ __html: sanitizeRenderedHtml(html) }}
+          />
+        </div>
+      </>
+    );
+  }
+
   return (
     <MarkdownRenderer
       content={rstToMarkdown(content)}

--- a/src/components/RstRenderer.tsx
+++ b/src/components/RstRenderer.tsx
@@ -34,7 +34,7 @@ export default function RstRenderer({ content, html, latex = false, slug, slugRe
         {latex && <KatexStyles />}
         <div className="bg-background">
           <div
-            className={proseClasses}
+            className={`${proseClasses} rst-rendered`}
             dangerouslySetInnerHTML={{ __html: sanitizeRenderedHtml(html) }}
           />
         </div>

--- a/src/layouts/PostLayout.tsx
+++ b/src/layouts/PostLayout.tsx
@@ -43,7 +43,7 @@ export default function PostLayout({ post, relatedPosts, seriesPosts, seriesTitl
     : `${siteConfig.baseUrl}${getPostUrl(post)}`;
   const commentSlug = isStaticPage ? `pages/${post.slug}` : post.slug;
   const bodyRenderer = post.sourceFormat === 'rst'
-    ? <RstRenderer content={post.content} latex={post.latex} slug={post.imageBaseSlug} slugRegistry={slugRegistry} />
+    ? <RstRenderer content={post.content} html={post.renderedHtml} latex={post.latex} slug={post.imageBaseSlug} slugRegistry={slugRegistry} />
     : <MarkdownRenderer content={post.content} latex={post.latex} slug={post.imageBaseSlug} slugRegistry={slugRegistry} />;
 
   return (

--- a/src/layouts/SimpleLayout.tsx
+++ b/src/layouts/SimpleLayout.tsx
@@ -31,7 +31,7 @@ export default function SimpleLayout({ post, titleKey, subtitleKey }: SimpleLayo
 
   const renderContent = (content: string) => (
     post.sourceFormat === 'rst'
-      ? <RstRenderer content={content} latex={post.latex} slug={post.imageBaseSlug} />
+      ? <RstRenderer content={content} html={content === post.content ? post.renderedHtml : undefined} latex={post.latex} slug={post.imageBaseSlug} />
       : <MarkdownRenderer content={content} latex={post.latex} slug={post.imageBaseSlug} />
   );
 

--- a/src/lib/markdown.ts
+++ b/src/lib/markdown.ts
@@ -162,6 +162,12 @@ const collectionPostsCache = new Map<string, Map<string, PostData[]>>();
 const collectionsForPostCache = new Map<string, Map<string, CollectionContext[]>>();
 let pythonRstRendererAvailable: boolean | null = null;
 
+function shouldUsePythonRstRenderer(): boolean {
+  if (process.env.AMYTIS_ENABLE_PYTHON_RST === '1') return true;
+  if (process.env.AMYTIS_ENABLE_PYTHON_RST === '0') return false;
+  return process.env.NODE_ENV !== 'test';
+}
+
 export function calculateReadingTime(content: string): string {
   const wordsPerMinute = 200;
   const hanCharsPerMinute = 300;
@@ -530,7 +536,7 @@ function parseRstFile(fullPath: string, slug: string, dateFromFileName?: string,
   let data: ReturnType<typeof parseRstDocument>['metadata'];
 
   try {
-    if (pythonRstRendererAvailable !== false) {
+    if (shouldUsePythonRstRenderer() && pythonRstRendererAvailable !== false) {
       const rendered = renderRstFile(fullPath, imageBaseSlug);
       pythonRstRendererAvailable = true;
       parsedTitle = rendered.title;

--- a/src/lib/markdown.ts
+++ b/src/lib/markdown.ts
@@ -576,13 +576,18 @@ function parseRstFile(fullPath: string, slug: string, dateFromFileName?: string,
   let parsedReadingTime: string;
   let parsedHtml: string | undefined;
   let data: ReturnType<typeof parseRstDocument>['metadata'];
+  const isPythonRuntimeUnavailable = (error: unknown): boolean => {
+    if (!(error instanceof Error)) return false;
+    if (error.message.includes('__RST_FALLBACK__')) return true;
+    return /docutils|No module named|not found|interpreter/i.test(error.message);
+  };
 
   try {
     if (shouldUsePythonRstRenderer() && pythonRstRendererAvailable !== false) {
       const rendered = renderRstFile(fullPath, imageBaseSlug);
       pythonRstRendererAvailable = true;
       parsedTitle = rendered.title;
-      parsedBody = fileContents;
+      parsedBody = rendered.text;
       parsedText = rendered.text;
       parsedHeadings = rendered.headings;
       parsedExcerpt = rendered.excerpt;
@@ -593,7 +598,10 @@ function parseRstFile(fullPath: string, slug: string, dateFromFileName?: string,
       throw new Error('__RST_FALLBACK__');
     }
   } catch (error) {
-    if (pythonRstRendererAvailable !== false && error instanceof Error && /docutils/i.test(error.message)) {
+    if (!isPythonRuntimeUnavailable(error)) {
+      throw error;
+    }
+    if (pythonRstRendererAvailable !== false) {
       pythonRstRendererAvailable = false;
     }
     const parsed = parseRstDocument(fileContents);

--- a/src/lib/markdown.ts
+++ b/src/lib/markdown.ts
@@ -6,6 +6,7 @@ import GithubSlugger from 'github-slugger';
 import { z } from 'zod';
 import { getPostUrl } from './urls';
 import { parseRstDocument } from './rst';
+import { renderRstFile } from './rst-renderer';
 
 const contentDirectory = path.join(process.cwd(), 'content', 'posts');
 const pagesDirectory = path.join(process.cwd(), 'content');
@@ -120,6 +121,8 @@ export interface PostData {
   redirectFrom?: string[];
   readingTime: string;
   content: string;
+  renderedHtml?: string;
+  plainText?: string;
   headings: Heading[];
   contentLocales?: Record<string, { content: string; title?: string; excerpt?: string; headings?: Heading[] }>;
   /** Public-relative base path used for resolving co-located images (e.g. "posts/my-post" or "posts" for root flat files). */
@@ -157,6 +160,7 @@ const allSeriesCache = new Map<string, Record<string, PostData[]>>();
 const featuredSeriesCache = new Map<string, Record<string, PostData[]>>();
 const collectionPostsCache = new Map<string, Map<string, PostData[]>>();
 const collectionsForPostCache = new Map<string, Map<string, CollectionContext[]>>();
+let pythonRstRendererAvailable: boolean | null = null;
 
 export function calculateReadingTime(content: string): string {
   const wordsPerMinute = 200;
@@ -511,13 +515,47 @@ function parseMarkdownFile(fullPath: string, slug: string, dateFromFileName?: st
 }
 
 function parseRstFile(fullPath: string, slug: string, dateFromFileName?: string, seriesName?: string): PostData {
-  const fileContents = fs.readFileSync(fullPath, 'utf8');
-  const parsed = parseRstDocument(fileContents);
-  const data = parsed.metadata;
-
   const isRootFlatPost = path.basename(fullPath) !== 'index.rst' &&
     path.dirname(fullPath) === contentDirectory;
   const imageBaseSlug = isRootFlatPost ? 'posts' : `posts/${slug}`;
+  const fileContents = fs.readFileSync(fullPath, 'utf8');
+
+  let parsedTitle: string;
+  let parsedBody: string;
+  let parsedText: string | undefined;
+  let parsedHeadings: Heading[];
+  let parsedExcerpt: string;
+  let parsedReadingTime: string;
+  let parsedHtml: string | undefined;
+  let data: ReturnType<typeof parseRstDocument>['metadata'];
+
+  try {
+    if (pythonRstRendererAvailable !== false) {
+      const rendered = renderRstFile(fullPath, imageBaseSlug);
+      pythonRstRendererAvailable = true;
+      parsedTitle = rendered.title;
+      parsedBody = fileContents;
+      parsedText = rendered.text;
+      parsedHeadings = rendered.headings;
+      parsedExcerpt = rendered.excerpt;
+      parsedReadingTime = rendered.readingTime;
+      parsedHtml = rendered.html;
+      data = rendered.metadata;
+    } else {
+      throw new Error('__RST_FALLBACK__');
+    }
+  } catch (error) {
+    if (pythonRstRendererAvailable !== false && error instanceof Error && /docutils/i.test(error.message)) {
+      pythonRstRendererAvailable = false;
+    }
+    const parsed = parseRstDocument(fileContents);
+    parsedTitle = parsed.title;
+    parsedBody = parsed.body;
+    parsedHeadings = parsed.headings;
+    parsedExcerpt = parsed.excerpt;
+    parsedReadingTime = parsed.readingTime;
+    data = parsed.metadata;
+  }
 
   const effectiveSeriesSlug = data.series || seriesName;
   let authors: string[] = [];
@@ -550,10 +588,10 @@ function parseRstFile(fullPath: string, slug: string, dateFromFileName?: string,
 
   return {
     slug,
-    title: parsed.title,
+    title: parsedTitle,
     subtitle: data.subtitle,
     date,
-    excerpt: data.excerpt || parsed.excerpt,
+    excerpt: data.excerpt || parsedExcerpt,
     category: data.category ?? 'Uncategorized',
     tags: data.tags ?? [],
     authors,
@@ -571,9 +609,11 @@ function parseRstFile(fullPath: string, slug: string, dateFromFileName?: string,
     toc: data.toc ?? true,
     commentable: data.commentable,
     redirectFrom: data.redirectFrom ?? [],
-    readingTime: parsed.readingTime,
-    content: parsed.body,
-    headings: parsed.headings,
+    readingTime: parsedReadingTime,
+    content: parsedBody,
+    renderedHtml: parsedHtml,
+    plainText: parsedText,
+    headings: parsedHeadings,
     imageBaseSlug,
     sourceFormat: 'rst',
   };

--- a/src/lib/markdown.ts
+++ b/src/lib/markdown.ts
@@ -160,6 +160,8 @@ const allSeriesCache = new Map<string, Record<string, PostData[]>>();
 const featuredSeriesCache = new Map<string, Record<string, PostData[]>>();
 const collectionPostsCache = new Map<string, Map<string, PostData[]>>();
 const collectionsForPostCache = new Map<string, Map<string, CollectionContext[]>>();
+const seriesAuthorsCache = new Map<string, Map<string, string[] | null>>();
+const seriesTitleCache = new Map<string, Map<string, string | undefined>>();
 let pythonRstRendererAvailable: boolean | null = null;
 
 function shouldUsePythonRstRenderer(): boolean {
@@ -226,27 +228,47 @@ export function getHeadings(content: string): Heading[] {
  * Returns null if no authors are configured (as opposed to the default fallback).
  */
 export function getSeriesAuthors(seriesSlug: string): string[] | null {
+  const cacheKey = getCacheEnvKey();
+  let bySlug = seriesAuthorsCache.get(cacheKey);
+  if (!bySlug) {
+    bySlug = new Map();
+    seriesAuthorsCache.set(cacheKey, bySlug);
+  }
+  if (bySlug.has(seriesSlug)) return bySlug.get(seriesSlug) ?? null;
+
   const indexInfo = resolveSeriesIndexInfo(seriesSlug);
-  if (!indexInfo) return null;
+  if (!indexInfo) {
+    bySlug.set(seriesSlug, null);
+    return null;
+  }
 
   if (indexInfo.format === 'rst') {
     const parsed = parseRstDocument(fs.readFileSync(indexInfo.fullPath, 'utf8'));
     if (parsed.metadata.authors && parsed.metadata.authors.length > 0) {
+      bySlug.set(seriesSlug, parsed.metadata.authors);
       return parsed.metadata.authors;
     }
     if (parsed.metadata.author && typeof parsed.metadata.author === 'string') {
-      return [parsed.metadata.author];
+      const authors = [parsed.metadata.author];
+      bySlug.set(seriesSlug, authors);
+      return authors;
     }
+    bySlug.set(seriesSlug, null);
     return null;
   }
 
   const { data } = matter(fs.readFileSync(indexInfo.fullPath, 'utf8'));
   if (data.authors && Array.isArray(data.authors) && data.authors.length > 0) {
-    return data.authors as string[];
+    const authors = data.authors as string[];
+    bySlug.set(seriesSlug, authors);
+    return authors;
   }
   if (data.author && typeof data.author === 'string') {
-    return [data.author as string];
+    const authors = [data.author as string];
+    bySlug.set(seriesSlug, authors);
+    return authors;
   }
+  bySlug.set(seriesSlug, null);
   return null;
 }
 
@@ -417,18 +439,38 @@ function getSeriesContentEntries(seriesSlug: string): SeriesContentEntry[] {
 }
 
 function getSeriesTitle(slug: string): string | undefined {
+  const cacheKey = getCacheEnvKey();
+  let bySlug = seriesTitleCache.get(cacheKey);
+  if (!bySlug) {
+    bySlug = new Map();
+    seriesTitleCache.set(cacheKey, bySlug);
+  }
+  if (bySlug.has(slug)) return bySlug.get(slug);
+
   const indexInfo = resolveSeriesIndexInfo(slug);
-  if (!indexInfo) return undefined;
+  if (!indexInfo) {
+    bySlug.set(slug, undefined);
+    return undefined;
+  }
 
   if (indexInfo.format === 'rst') {
     const parsed = parseRstDocument(fs.readFileSync(indexInfo.fullPath, 'utf8'));
-    if (parsed.metadata.draft === true) return undefined;
+    if (parsed.metadata.draft === true) {
+      bySlug.set(slug, undefined);
+      return undefined;
+    }
+    bySlug.set(slug, parsed.title);
     return parsed.title;
   }
 
   const { data } = matter(fs.readFileSync(indexInfo.fullPath, 'utf8'));
-  if (data.draft === true) return undefined;
-  return typeof data.title === 'string' ? data.title : undefined;
+  if (data.draft === true) {
+    bySlug.set(slug, undefined);
+    return undefined;
+  }
+  const title = typeof data.title === 'string' ? data.title : undefined;
+  bySlug.set(slug, title);
+  return title;
 }
 
 function parseMarkdownFile(fullPath: string, slug: string, dateFromFileName?: string, seriesName?: string): PostData {

--- a/src/lib/rst-renderer.test.ts
+++ b/src/lib/rst-renderer.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, test } from 'bun:test';
+import { normalizePythonRstMetadata, renderRstFile, validatePythonRstResult } from './rst-renderer';
+import { RstParseError } from './rst';
+
+describe('rst-renderer bridge', () => {
+  test('normalizes python metadata using the existing rst rules', () => {
+    const metadata = normalizePythonRstMetadata({
+      date: '2026-04-07',
+      tags: ['rst', 'docs'],
+      featured: false,
+      redirectFrom: ['/series/old-slug'],
+      coverImage: './images/cover.png',
+      customField: 'ignored',
+    });
+
+    expect(metadata).toEqual({
+      date: '2026-04-07',
+      tags: ['rst', 'docs'],
+      featured: false,
+      redirectFrom: ['/series/old-slug'],
+      coverImage: './images/cover.png',
+    });
+  });
+
+  test('rejects malformed supported metadata from python output', () => {
+    expect(() => normalizePythonRstMetadata({ draft: 'maybe' })).toThrow(RstParseError);
+    expect(() => normalizePythonRstMetadata({ date: '2026-16-01' })).toThrow(RstParseError);
+    expect(() => normalizePythonRstMetadata({ type: 'post' })).toThrow(RstParseError);
+  });
+
+  test('validates the expected python renderer result shape', () => {
+    expect(() => validatePythonRstResult({
+      title: 'Title',
+      html: '<p>Body</p>',
+      text: 'Body',
+      headings: [{ id: 'body', text: 'Body', level: 2 }],
+      metadata: {},
+      assets: [{ original: './a.png', resolved: '/posts/x/a.png', exists: true }],
+      warnings: [],
+    }, 'content/series/example/index.rst')).not.toThrow();
+
+    expect(() => validatePythonRstResult({
+      title: '',
+      html: '<p>Body</p>',
+      text: 'Body',
+      headings: [],
+      metadata: {},
+    }, 'broken.rst')).toThrow(RstParseError);
+  });
+
+  test('renderRstFile surfaces the missing docutils dependency clearly', () => {
+    expect(() => renderRstFile(
+      'content/series/rst-legacy/index.rst',
+      'posts/rst-legacy'
+    )).toThrow(/docutils/i);
+  });
+});

--- a/src/lib/rst-renderer.test.ts
+++ b/src/lib/rst-renderer.test.ts
@@ -114,4 +114,17 @@ describe('rst-renderer bridge', () => {
     expect(doc.warnings[0]).toContain('../道德经直译/道具体是指什么');
     expect(doc.warnings[1]).toContain('../道德经直译/无名');
   });
+
+  fixtureTest('renders real code blocks through docutils with pygments classes', () => {
+    const doc = renderRstFile(
+      'content/series/软件构架设计/大型软件架构设计.rst',
+      'posts/大型软件架构设计'
+    );
+
+    expect(doc.warnings).toEqual([]);
+    expect(doc.html).toContain('<pre class="code python literal-block">');
+    expect(doc.html).toContain('<span class="keyword">def</span>');
+    expect(doc.html).toContain('<span class="name function">search</span>');
+    expect(doc.text).toContain('def search(key, strings):');
+  });
 });

--- a/src/lib/rst-renderer.test.ts
+++ b/src/lib/rst-renderer.test.ts
@@ -88,4 +88,30 @@ describe('rst-renderer bridge', () => {
     expect(doc.text.includes('\n\n0.2\n\n')).toBe(false);
     expect(doc.excerpt.startsWith('关于队列模型')).toBe(true);
   });
+
+  fixtureTest('rewrites same-series :doc: links to site URLs', () => {
+    const doc = renderRstFile(
+      'content/series/软件构架设计/从香农熵谈设计文档写作.rst',
+      'posts/从香农熵谈设计文档写作'
+    );
+
+    expect(doc.html).toContain('href="/软件构架设计/开发视图"');
+    expect(doc.html).not.toContain('system-message');
+    expect(doc.text.includes('No role entry for "doc"')).toBe(false);
+    expect(doc.warnings).toEqual([]);
+  });
+
+  fixtureTest('falls back cleanly for unresolved external-style :doc: targets', () => {
+    const doc = renderRstFile(
+      'content/series/软件构架设计/无名概念的深入探讨.rst',
+      'posts/无名概念的深入探讨'
+    );
+
+    expect(doc.html).not.toContain('system-message');
+    expect(doc.html).toContain('<span class="docutils literal">道具体是指什么</span>');
+    expect(doc.html).toContain('href="/软件构架设计/弟子规：美国军方禁止在C语言程序中使用malloc"');
+    expect(doc.warnings.length).toBe(2);
+    expect(doc.warnings[0]).toContain('../道德经直译/道具体是指什么');
+    expect(doc.warnings[1]).toContain('../道德经直译/无名');
+  });
 });

--- a/src/lib/rst-renderer.test.ts
+++ b/src/lib/rst-renderer.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test';
-import { normalizePythonRstMetadata, renderRstFile, validatePythonRstResult } from './rst-renderer';
+import { normalizePythonRstMetadata, validatePythonRstResult } from './rst-renderer';
 import { RstParseError } from './rst';
 
 describe('rst-renderer bridge', () => {
@@ -46,12 +46,5 @@ describe('rst-renderer bridge', () => {
       headings: [],
       metadata: {},
     }, 'broken.rst')).toThrow(RstParseError);
-  });
-
-  test('renderRstFile surfaces the missing docutils dependency clearly', () => {
-    expect(() => renderRstFile(
-      'content/series/rst-legacy/index.rst',
-      'posts/rst-legacy'
-    )).toThrow(/docutils/i);
   });
 });

--- a/src/lib/rst-renderer.test.ts
+++ b/src/lib/rst-renderer.test.ts
@@ -4,8 +4,13 @@ import { describe, expect, test } from 'bun:test';
 import { normalizePythonRstMetadata, renderRstFile, validatePythonRstResult } from './rst-renderer';
 import { RstParseError } from './rst';
 
-const hasLocalDocutils = existsSync(path.join(process.cwd(), '.venv-rst', 'bin', 'python'));
+const localDocutilsPython = path.join(process.cwd(), '.venv-rst', 'bin', 'python');
+const hasLocalDocutils = existsSync(localDocutilsPython);
 const fixtureTest = hasLocalDocutils ? test : test.skip;
+
+if (hasLocalDocutils) {
+  process.env.AMYTIS_RST_PYTHON = localDocutilsPython;
+}
 
 describe('rst-renderer bridge', () => {
   test('normalizes python metadata using the existing rst rules', () => {

--- a/src/lib/rst-renderer.test.ts
+++ b/src/lib/rst-renderer.test.ts
@@ -127,4 +127,27 @@ describe('rst-renderer bridge', () => {
     expect(doc.html).toContain('<span class="name function">search</span>');
     expect(doc.text).toContain('def search(key, strings):');
   });
+
+  fixtureTest('renders unsupported legacy roles as inline text instead of system-message blocks', () => {
+    const doc = renderRstFile(
+      'content/series/软件构架设计/为什么很多人看书学不会架构设计.rst',
+      'posts/为什么很多人看书学不会架构设计'
+    );
+
+    expect(doc.html).not.toContain('system-message');
+    expect(doc.html).toContain('<span class="dtag">架构设计定义</span>');
+    expect(doc.warnings).toContain('Unsupported interpreted text role ":dtag:" rendered as plain inline text.');
+  });
+
+  fixtureTest('does not include footnote bodies in extracted plain text', () => {
+    const doc = renderRstFile(
+      'content/series/软件构架设计/把什么放入架构设计.rst',
+      'posts/把什么放入架构设计'
+    );
+
+    expect(doc.html).toContain('class="footnote-list brackets"');
+    expect(doc.text).not.toContain('我这里说争论纯粹是指技术上的真理探讨');
+    expect(doc.text).not.toContain('关于这一点，可以参考这里：计算进化史');
+    expect(doc.excerpt).not.toContain('我这里说争论纯粹是指技术上的真理探讨');
+  });
 });

--- a/src/lib/rst-renderer.test.ts
+++ b/src/lib/rst-renderer.test.ts
@@ -162,16 +162,17 @@ describe('rst-renderer bridge', () => {
     expect(doc.text.includes(':ref:`s_extension`')).toBe(false);
   });
 
-  fixtureTest('renders legacy :numref: roles as readable inline text instead of system-message blocks', () => {
+  fixtureTest('resolves legacy :numref: roles to figure anchors when labels exist', () => {
     const doc = renderRstFile(
       'content/series/软件构架设计/逻辑如水.rst',
       'posts/逻辑如水'
     );
 
     expect(doc.html).not.toContain('system-message');
-    expect(doc.html).toContain('<span class="numref">图：模拟的特征</span>');
-    expect(doc.html).toContain('<span class="numref">图：模拟特征的数字化过程</span>');
-    expect(doc.warnings).toContain('Unsupported interpreted text role ":numref:" rendered as plain inline text.');
+    expect(doc.html).toContain('href="#target-1"');
+    expect(doc.html).toContain('href="#target-2"');
+    expect(doc.html).toContain('class="reference external numref"');
+    expect(doc.warnings).not.toContain('Unsupported interpreted text role ":numref:" rendered as plain inline text.');
   });
 
   fixtureTest('renders legacy :math: roles as MathML without leaking raw inline syntax', () => {

--- a/src/lib/rst-renderer.test.ts
+++ b/src/lib/rst-renderer.test.ts
@@ -1,6 +1,11 @@
+import { existsSync } from 'node:fs';
+import path from 'node:path';
 import { describe, expect, test } from 'bun:test';
-import { normalizePythonRstMetadata, validatePythonRstResult } from './rst-renderer';
+import { normalizePythonRstMetadata, renderRstFile, validatePythonRstResult } from './rst-renderer';
 import { RstParseError } from './rst';
+
+const hasLocalDocutils = existsSync(path.join(process.cwd(), '.venv-rst', 'bin', 'python'));
+const fixtureTest = hasLocalDocutils ? test : test.skip;
 
 describe('rst-renderer bridge', () => {
   test('normalizes python metadata using the existing rst rules', () => {
@@ -46,5 +51,41 @@ describe('rst-renderer bridge', () => {
       headings: [],
       metadata: {},
     }, 'broken.rst')).toThrow(RstParseError);
+  });
+
+  fixtureTest('renders a real legacy rST page with rewritten figure asset URLs', () => {
+    const doc = renderRstFile(
+      'content/series/软件构架设计/关于队列模型.rst',
+      'posts/关于队列模型'
+    );
+
+    expect(doc.title).toBe('关于队列模型');
+    expect(doc.headings).toEqual([{ id: 'section-1', text: '关于队列模型', level: 2 }]);
+    expect(doc.assets).toEqual([
+      {
+        original: '_static/fsm_vs_queue.svg',
+        resolved: '/posts/关于队列模型/_static/fsm_vs_queue.svg',
+        exists: true,
+      },
+      {
+        original: '_static/para_queue_model.svg',
+        resolved: '/posts/关于队列模型/_static/para_queue_model.svg',
+        exists: true,
+      },
+    ]);
+    expect(doc.html).toContain('/posts/关于队列模型/_static/fsm_vs_queue.svg');
+    expect(doc.html).toContain('/posts/关于队列模型/_static/para_queue_model.svg');
+  });
+
+  fixtureTest('derives excerpt and text from body content instead of docinfo', () => {
+    const doc = renderRstFile(
+      'content/series/软件构架设计/关于队列模型.rst',
+      'posts/关于队列模型'
+    );
+
+    expect(doc.text.startsWith('关于队列模型')).toBe(true);
+    expect(doc.text.includes('Kenneth Lee 版权所有 2024')).toBe(false);
+    expect(doc.text.includes('\n\n0.2\n\n')).toBe(false);
+    expect(doc.excerpt.startsWith('关于队列模型')).toBe(true);
   });
 });

--- a/src/lib/rst-renderer.test.ts
+++ b/src/lib/rst-renderer.test.ts
@@ -150,4 +150,27 @@ describe('rst-renderer bridge', () => {
     expect(doc.text).not.toContain('关于这一点，可以参考这里：计算进化史');
     expect(doc.excerpt).not.toContain('我这里说争论纯粹是指技术上的真理探讨');
   });
+
+  fixtureTest('renders legacy :ref: roles as internal links instead of system-message blocks', () => {
+    const doc = renderRstFile(
+      'content/series/软件构架设计/对一个设计评审意见的深入探讨.rst',
+      'posts/对一个设计评审意见的深入探讨'
+    );
+
+    expect(doc.html).not.toContain('system-message');
+    expect(doc.html).toContain('href="#s-extension"');
+    expect(doc.text.includes(':ref:`s_extension`')).toBe(false);
+  });
+
+  fixtureTest('renders legacy :numref: roles as readable inline text instead of system-message blocks', () => {
+    const doc = renderRstFile(
+      'content/series/软件构架设计/逻辑如水.rst',
+      'posts/逻辑如水'
+    );
+
+    expect(doc.html).not.toContain('system-message');
+    expect(doc.html).toContain('<span class="numref">图：模拟的特征</span>');
+    expect(doc.html).toContain('<span class="numref">图：模拟特征的数字化过程</span>');
+    expect(doc.warnings).toContain('Unsupported interpreted text role ":numref:" rendered as plain inline text.');
+  });
 });

--- a/src/lib/rst-renderer.test.ts
+++ b/src/lib/rst-renderer.test.ts
@@ -173,4 +173,16 @@ describe('rst-renderer bridge', () => {
     expect(doc.html).toContain('<span class="numref">图：模拟特征的数字化过程</span>');
     expect(doc.warnings).toContain('Unsupported interpreted text role ":numref:" rendered as plain inline text.');
   });
+
+  fixtureTest('renders legacy :math: roles as MathML without leaking raw inline syntax', () => {
+    const doc = renderRstFile(
+      'content/series/软件构架设计/逻辑闭包.rst',
+      'posts/逻辑闭包'
+    );
+
+    expect(doc.html).toContain('<math xmlns="http://www.w3.org/1998/Math/MathML">');
+    expect(doc.html).toContain('<mi>H</mi>');
+    expect(doc.html).toContain('<msub>');
+    expect(doc.text.includes(':math:`H=-\\sum_{i=0}^n\\ P_ilogP_i`')).toBe(false);
+  });
 });

--- a/src/lib/rst-renderer.test.ts
+++ b/src/lib/rst-renderer.test.ts
@@ -77,6 +77,18 @@ describe('rst-renderer bridge', () => {
     expect(doc.html).toContain('/posts/关于队列模型/_static/para_queue_model.svg');
   });
 
+  fixtureTest('preserves series index metadata fields from docutils output', () => {
+    const doc = renderRstFile(
+      'content/series/rst-legacy/index.rst',
+      'posts/rst-legacy'
+    );
+
+    expect(doc.metadata.excerpt).toBe('Legacy notes imported from reStructuredText.');
+    expect(doc.metadata.sort).toBe('manual');
+    expect(doc.metadata.posts).toEqual(['getting-started', 'deeper-notes']);
+    expect(doc.metadata.authors).toEqual(['John Hu']);
+  });
+
   fixtureTest('derives excerpt and text from body content instead of docinfo', () => {
     const doc = renderRstFile(
       'content/series/软件构架设计/关于队列模型.rst',

--- a/src/lib/rst-renderer.test.ts
+++ b/src/lib/rst-renderer.test.ts
@@ -1,16 +1,27 @@
 import { existsSync } from 'node:fs';
 import path from 'node:path';
-import { describe, expect, test } from 'bun:test';
+import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
 import { normalizePythonRstMetadata, renderRstFile, validatePythonRstResult } from './rst-renderer';
 import { RstParseError } from './rst';
 
 const localDocutilsPython = path.join(process.cwd(), '.venv-rst', 'bin', 'python');
 const hasLocalDocutils = existsSync(localDocutilsPython);
 const fixtureTest = hasLocalDocutils ? test : test.skip;
+const previousPython = process.env.AMYTIS_RST_PYTHON;
 
-if (hasLocalDocutils) {
-  process.env.AMYTIS_RST_PYTHON = localDocutilsPython;
-}
+beforeAll(() => {
+  if (hasLocalDocutils && previousPython === undefined) {
+    process.env.AMYTIS_RST_PYTHON = localDocutilsPython;
+  }
+});
+
+afterAll(() => {
+  if (previousPython === undefined) {
+    delete process.env.AMYTIS_RST_PYTHON;
+  } else {
+    process.env.AMYTIS_RST_PYTHON = previousPython;
+  }
+});
 
 describe('rst-renderer bridge', () => {
   test('normalizes python metadata using the existing rst rules', () => {

--- a/src/lib/rst-renderer.ts
+++ b/src/lib/rst-renderer.ts
@@ -1,3 +1,4 @@
+import fs from 'node:fs';
 import { spawnSync } from 'node:child_process';
 import path from 'node:path';
 import { RstMetadata, RstParseError } from './rst';
@@ -34,6 +35,11 @@ export interface RenderedRstDocument {
   readingTime: string;
   assets: PythonRstAsset[];
   warnings: string[];
+}
+
+function getPythonExecutableForRstRenderer(): string {
+  const localVenvPython = path.join(process.cwd(), '.venv-rst', 'bin', 'python');
+  return fs.existsSync(localVenvPython) ? localVenvPython : 'python3';
 }
 
 function parseBoolean(field: string, value: unknown): boolean {
@@ -233,7 +239,8 @@ export function validatePythonRstResult(result: PythonRstRenderResult, filePath:
 
 export function runPythonRstRenderer(filePath: string, imageBaseSlug: string): PythonRstRenderResult {
   const scriptPath = path.join(process.cwd(), 'scripts', 'render-rst.py');
-  const result = spawnSync('python3', [
+  const pythonExecutable = getPythonExecutableForRstRenderer();
+  const result = spawnSync(pythonExecutable, [
     scriptPath,
     '--file',
     filePath,

--- a/src/lib/rst-renderer.ts
+++ b/src/lib/rst-renderer.ts
@@ -1,0 +1,282 @@
+import { spawnSync } from 'node:child_process';
+import path from 'node:path';
+import { RstMetadata, RstParseError } from './rst';
+
+export interface PythonRstHeading {
+  id: string;
+  text: string;
+  level: number;
+}
+
+export interface PythonRstAsset {
+  original: string;
+  resolved: string;
+  exists: boolean;
+}
+
+export interface PythonRstRenderResult {
+  title: string;
+  html: string;
+  text: string;
+  headings: PythonRstHeading[];
+  metadata: Record<string, unknown>;
+  assets?: PythonRstAsset[];
+  warnings?: string[];
+}
+
+export interface RenderedRstDocument {
+  title: string;
+  html: string;
+  text: string;
+  headings: PythonRstHeading[];
+  metadata: RstMetadata;
+  excerpt: string;
+  readingTime: string;
+  assets: PythonRstAsset[];
+  warnings: string[];
+}
+
+function parseBoolean(field: string, value: unknown): boolean {
+  if (value === true || value === false) return value;
+  if (typeof value === 'string') {
+    if (value === 'true') return true;
+    if (value === 'false') return false;
+  }
+  throw new RstParseError(`Invalid boolean for "${field}": ${String(value)}`);
+}
+
+function parseString(field: string, value: unknown): string {
+  if (typeof value !== 'string') {
+    throw new RstParseError(`Invalid value for "${field}": ${String(value)}`);
+  }
+  return value.trim();
+}
+
+function parseStringArray(field: string, value: unknown): string[] {
+  if (Array.isArray(value)) {
+    return value.map((item) => parseString(field, item)).filter(Boolean);
+  }
+  if (typeof value === 'string') {
+    return value
+      .split(',')
+      .map((item) => item.trim())
+      .filter(Boolean);
+  }
+  throw new RstParseError(`Invalid list for "${field}": ${String(value)}`);
+}
+
+function parseDate(value: unknown): string {
+  const date = parseString('date', value);
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) {
+    throw new RstParseError(`Invalid date: ${date}`);
+  }
+
+  const parsed = new Date(`${date}T00:00:00Z`);
+  if (Number.isNaN(parsed.getTime()) || parsed.toISOString().slice(0, 10) !== date) {
+    throw new RstParseError(`Invalid date: ${date}`);
+  }
+
+  return date;
+}
+
+function parseSort(value: unknown): 'date-desc' | 'date-asc' | 'manual' {
+  const sort = parseString('sort', value);
+  if (sort === 'date-desc' || sort === 'date-asc' || sort === 'manual') {
+    return sort;
+  }
+  throw new RstParseError(`Invalid sort value: ${sort}`);
+}
+
+function parseType(value: unknown): 'collection' {
+  const type = parseString('type', value);
+  if (type === 'collection') return type;
+  throw new RstParseError(`Invalid type value: ${type}`);
+}
+
+export function normalizePythonRstMetadata(metadata: Record<string, unknown>): RstMetadata {
+  const normalized: RstMetadata = {};
+
+  for (const [rawKey, rawValue] of Object.entries(metadata)) {
+    const key = rawKey.toLowerCase();
+
+    switch (key) {
+      case 'date':
+        normalized.date = parseDate(rawValue);
+        break;
+      case 'subtitle':
+        normalized.subtitle = parseString('subtitle', rawValue);
+        break;
+      case 'excerpt':
+        normalized.excerpt = parseString('excerpt', rawValue);
+        break;
+      case 'category':
+        normalized.category = parseString('category', rawValue);
+        break;
+      case 'tags':
+        normalized.tags = parseStringArray('tags', rawValue);
+        break;
+      case 'authors':
+        normalized.authors = parseStringArray('authors', rawValue);
+        break;
+      case 'author':
+        normalized.author = parseString('author', rawValue);
+        break;
+      case 'layout':
+        normalized.layout = parseString('layout', rawValue);
+        break;
+      case 'series':
+        normalized.series = parseString('series', rawValue);
+        break;
+      case 'coverimage':
+      case 'coverImage':
+        normalized.coverImage = parseString('coverImage', rawValue);
+        break;
+      case 'sort':
+        normalized.sort = parseSort(rawValue);
+        break;
+      case 'posts':
+        normalized.posts = parseStringArray('posts', rawValue);
+        break;
+      case 'featured':
+        normalized.featured = parseBoolean('featured', rawValue);
+        break;
+      case 'pinned':
+        normalized.pinned = parseBoolean('pinned', rawValue);
+        break;
+      case 'draft':
+        normalized.draft = parseBoolean('draft', rawValue);
+        break;
+      case 'latex':
+        normalized.latex = parseBoolean('latex', rawValue);
+        break;
+      case 'toc':
+        normalized.toc = parseBoolean('toc', rawValue);
+        break;
+      case 'commentable':
+        normalized.commentable = parseBoolean('commentable', rawValue);
+        break;
+      case 'redirectfrom':
+      case 'redirectFrom':
+        normalized.redirectFrom = parseStringArray('redirectFrom', rawValue);
+        break;
+      case 'type':
+        normalized.type = parseType(rawValue);
+        break;
+      default:
+        break;
+    }
+  }
+
+  return normalized;
+}
+
+function calculateReadingTimeFromText(text: string): string {
+  const wordsPerMinute = 200;
+  const hanCharsPerMinute = 300;
+
+  const hanCharCount = (text.match(/[\u3400-\u4DBF\u4E00-\u9FFF\uF900-\uFAFF]/g) || []).length;
+  const latinWordCount = (text.match(/[A-Za-z0-9]+(?:['’-][A-Za-z0-9]+)*/g) || []).length;
+
+  const estimatedMinutes = (latinWordCount / wordsPerMinute) + (hanCharCount / hanCharsPerMinute);
+  return `${Math.max(1, Math.ceil(estimatedMinutes))} min read`;
+}
+
+function generateExcerptFromText(text: string): string {
+  const plain = text.replace(/\s+/g, ' ').trim();
+  if (plain.length <= 160) return plain;
+  return `${plain.slice(0, 160).trim()}...`;
+}
+
+export function validatePythonRstResult(result: PythonRstRenderResult, filePath: string): void {
+  if (!result || typeof result !== 'object') {
+    throw new RstParseError(`Invalid renderer output for ${filePath}: expected object.`);
+  }
+
+  if (typeof result.title !== 'string' || !result.title.trim()) {
+    throw new RstParseError(`Invalid renderer output for ${filePath}: missing title.`);
+  }
+  if (typeof result.html !== 'string') {
+    throw new RstParseError(`Invalid renderer output for ${filePath}: missing html.`);
+  }
+  if (typeof result.text !== 'string') {
+    throw new RstParseError(`Invalid renderer output for ${filePath}: missing text.`);
+  }
+  if (!Array.isArray(result.headings)) {
+    throw new RstParseError(`Invalid renderer output for ${filePath}: headings must be an array.`);
+  }
+  if (!result.headings.every((heading) =>
+    heading &&
+    typeof heading.id === 'string' &&
+    typeof heading.text === 'string' &&
+    typeof heading.level === 'number'
+  )) {
+    throw new RstParseError(`Invalid renderer output for ${filePath}: malformed heading entry.`);
+  }
+  if (!result.metadata || typeof result.metadata !== 'object' || Array.isArray(result.metadata)) {
+    throw new RstParseError(`Invalid renderer output for ${filePath}: metadata must be an object.`);
+  }
+  if (result.assets && !Array.isArray(result.assets)) {
+    throw new RstParseError(`Invalid renderer output for ${filePath}: assets must be an array.`);
+  }
+  if (result.assets && !result.assets.every((asset) =>
+    asset &&
+    typeof asset.original === 'string' &&
+    typeof asset.resolved === 'string' &&
+    typeof asset.exists === 'boolean'
+  )) {
+    throw new RstParseError(`Invalid renderer output for ${filePath}: malformed asset entry.`);
+  }
+  if (result.warnings && !Array.isArray(result.warnings)) {
+    throw new RstParseError(`Invalid renderer output for ${filePath}: warnings must be an array.`);
+  }
+}
+
+export function runPythonRstRenderer(filePath: string, imageBaseSlug: string): PythonRstRenderResult {
+  const scriptPath = path.join(process.cwd(), 'scripts', 'render-rst.py');
+  const result = spawnSync('python3', [
+    scriptPath,
+    '--file',
+    filePath,
+    '--image-base-slug',
+    imageBaseSlug,
+    '--strict',
+  ], {
+    encoding: 'utf8',
+  });
+
+  if (result.error) {
+    throw new RstParseError(`Failed to run Python rST renderer for ${filePath}: ${result.error.message}`);
+  }
+
+  if (result.status !== 0) {
+    throw new RstParseError(
+      result.stderr.trim() || `Python rST renderer exited with status ${result.status} for ${filePath}.`
+    );
+  }
+
+  try {
+    return JSON.parse(result.stdout) as PythonRstRenderResult;
+  } catch (error) {
+    throw new RstParseError(
+      `Invalid JSON from Python rST renderer for ${filePath}: ${error instanceof Error ? error.message : String(error)}`
+    );
+  }
+}
+
+export function renderRstFile(filePath: string, imageBaseSlug: string): RenderedRstDocument {
+  const result = runPythonRstRenderer(filePath, imageBaseSlug);
+  validatePythonRstResult(result, filePath);
+  const metadata = normalizePythonRstMetadata(result.metadata);
+
+  return {
+    title: result.title,
+    html: result.html,
+    text: result.text,
+    headings: result.headings,
+    metadata,
+    excerpt: metadata.excerpt || generateExcerptFromText(result.text),
+    readingTime: calculateReadingTimeFromText(result.text),
+    assets: result.assets ?? [],
+    warnings: (result.warnings ?? []).map((warning) => String(warning)),
+  };
+}

--- a/src/lib/rst-renderer.ts
+++ b/src/lib/rst-renderer.ts
@@ -1,4 +1,3 @@
-import fs from 'node:fs';
 import { spawnSync } from 'node:child_process';
 import path from 'node:path';
 import { RstMetadata, RstParseError } from './rst';
@@ -38,8 +37,7 @@ export interface RenderedRstDocument {
 }
 
 function getPythonExecutableForRstRenderer(): string {
-  const localVenvPython = path.join(process.cwd(), '.venv-rst', 'bin', 'python');
-  return fs.existsSync(localVenvPython) ? localVenvPython : 'python3';
+  return process.env.AMYTIS_RST_PYTHON || 'python3';
 }
 
 function parseBoolean(field: string, value: unknown): boolean {

--- a/tests/integration/series-draft.test.ts
+++ b/tests/integration/series-draft.test.ts
@@ -18,20 +18,25 @@ describe("Integration: Series Draft Support", () => {
 
   test("draft filtering code path runs without error in production mode", () => {
     const originalEnv = process.env.NODE_ENV;
+    const originalPythonRst = process.env.AMYTIS_ENABLE_PYTHON_RST;
     try {
       process.env.NODE_ENV = "production";
+      process.env.AMYTIS_ENABLE_PYTHON_RST = "0";
       // This should not throw; draft series are simply excluded
       const series = getAllSeries();
       expect(typeof series).toBe("object");
     } finally {
       process.env.NODE_ENV = originalEnv;
+      process.env.AMYTIS_ENABLE_PYTHON_RST = originalPythonRst;
     }
   });
 
   test("draft series are excluded in production mode", () => {
     const originalEnv = process.env.NODE_ENV;
+    const originalPythonRst = process.env.AMYTIS_ENABLE_PYTHON_RST;
     try {
       process.env.NODE_ENV = "production";
+      process.env.AMYTIS_ENABLE_PYTHON_RST = "0";
       const allSeries = getAllSeries();
       
       // Verify that every series returned has draft: false (or undefined which defaults to false)
@@ -41,6 +46,7 @@ describe("Integration: Series Draft Support", () => {
       });
     } finally {
       process.env.NODE_ENV = originalEnv;
+      process.env.AMYTIS_ENABLE_PYTHON_RST = originalPythonRst;
     }
   });
 });

--- a/tests/integration/series-draft.test.ts
+++ b/tests/integration/series-draft.test.ts
@@ -1,6 +1,14 @@
 import { describe, expect, test } from "bun:test";
 import { getSeriesData, getAllSeries } from "../../src/lib/markdown";
 
+function restoreEnvVar(key: string, value: string | undefined): void {
+  if (value === undefined) {
+    delete process.env[key];
+  } else {
+    process.env[key] = value;
+  }
+}
+
 describe("Integration: Series Draft Support", () => {
   test("all series are included when NODE_ENV is not production", () => {
     // In test environment NODE_ENV is typically 'test'
@@ -26,8 +34,8 @@ describe("Integration: Series Draft Support", () => {
       const series = getAllSeries();
       expect(typeof series).toBe("object");
     } finally {
-      process.env.NODE_ENV = originalEnv;
-      process.env.AMYTIS_ENABLE_PYTHON_RST = originalPythonRst;
+      restoreEnvVar("NODE_ENV", originalEnv);
+      restoreEnvVar("AMYTIS_ENABLE_PYTHON_RST", originalPythonRst);
     }
   });
 
@@ -45,8 +53,8 @@ describe("Integration: Series Draft Support", () => {
         expect(seriesData?.draft).not.toBe(true);
       });
     } finally {
-      process.env.NODE_ENV = originalEnv;
-      process.env.AMYTIS_ENABLE_PYTHON_RST = originalPythonRst;
+      restoreEnvVar("NODE_ENV", originalEnv);
+      restoreEnvVar("AMYTIS_ENABLE_PYTHON_RST", originalPythonRst);
     }
   });
 });


### PR DESCRIPTION
## Summary

This PR upgrades series-scoped rST support to a docutils-backed, HTML-first rendering path.

Markdown behavior stays unchanged. rST series now render through a Python/docutils bridge with improved compatibility for imported legacy content, plus follow-up fixes for build/test stability.

## Highlights

- add `scripts/render-rst.py` and `src/lib/rst-renderer.ts`
- integrate Python/docutils rendering into the rST loader
- render rST content from pre-rendered HTML instead of converting to Markdown
- rewrite local `.. image::` / `.. figure::` asset URLs
- improve excerpts, reading time, and heading extraction for real rST pages
- add compatibility handling for legacy `:doc:`, `:dtag:`, `:ref:`, `:numref:`, and `:math:` usage
- improve styling for docutils output: figures, notes, footnotes, code blocks, inline tags, MathML
- support README-based series indexes and Unicode series paths
- fix build/test issues introduced by the new renderer path

## Validation

- `bun run validate`

## Notes

- runtime uses `AMYTIS_RST_PYTHON` when set, otherwise `python3`
- tests only opt into the local `.venv-rst` docutils interpreter when it exists
- unresolved legacy constructs still degrade gracefully in a few places rather than aiming for full Sphinx parity


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Pre-rendered RST HTML support for faster, higher-fidelity post rendering with sanitization of scripts and inline handlers.
  * Added a CLI renderer to convert reStructuredText into structured JSON/HTML for the build pipeline.

* **Style**
  * Enhanced RST styles: figures, captions, admonitions, code blocks, footnotes, math, and dark-mode refinements.

* **Tests**
  * New unit and integration tests for RST rendering, metadata, assets, and sanitizer behavior.

* **Chores**
  * Ignore local Python virtualenv artifacts from linting and source control.
* **Documentation**
  * Added roadmap tasks for build performance and expanded rST follow-ups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->