### PR TITLE
perf: reduce rst build-time overhead

### DIFF
--- a/scripts/generate-knowledge-graph.ts
+++ b/scripts/generate-knowledge-graph.ts
@@ -41,6 +41,7 @@ async function main() {
   const posts = getAllPosts();
   const notes = getAllNotes();
   const flows = getAllFlows();
+  const flowMap = new Map(flows.map(flow => [flow.slug, flow] as const));
 
   // Build id→node map
   const nodeMap = new Map<string, GraphNode>();
@@ -80,7 +81,7 @@ async function main() {
         if (item.type === 'flow') linkedFlowSlugs.add(item.slug);
       }
       // Track referenced flows
-      const targetFlow = flows.find(f => f.slug === target);
+      const targetFlow = flowMap.get(target);
       if (targetFlow) {
         linkedFlowSlugs.add(target);
         if (!nodeMap.has(target)) {

--- a/scripts/render-rst.py
+++ b/scripts/render-rst.py
@@ -542,6 +542,7 @@ def render_batch(strict: bool) -> list[dict[str, Any]]:
 
 def main() -> int:
     args = parse_args()
+    source_file: Path | None = None
 
     try:
         from docutils.core import publish_doctree  # noqa: F401
@@ -568,7 +569,10 @@ def main() -> int:
         print(str(exc), file=sys.stderr)
         return 1
     except (OSError, ValueError, KeyError, AttributeError) as exc:
-        print(f"Failed to render {source_file}: {exc}", file=sys.stderr)
+        if source_file is not None:
+            print(f"Failed to render {source_file}: {exc}", file=sys.stderr)
+        else:
+            print(f"Failed to render: {exc}", file=sys.stderr)
         return 1
     except Exception:
         raise

--- a/scripts/render-rst.py
+++ b/scripts/render-rst.py
@@ -225,8 +225,8 @@ def parse_args() -> argparse.Namespace:
 def resolve_source_file(raw_file: str) -> Path:
     source_file = Path(raw_file).expanduser()
     if not source_file.is_absolute():
-        source_file = (Path.cwd() / source_file).resolve()
-    return source_file
+        source_file = Path.cwd() / source_file
+    return source_file.resolve()
 
 
 def normalize_metadata_value(key: str, value: str) -> Any:
@@ -516,26 +516,14 @@ def render_batch(strict: bool) -> list[dict[str, Any]]:
 
         source_file = resolve_source_file(raw_file)
         if not source_file.exists():
-            results.append({
-                "file": str(source_file),
-                "ok": False,
-                "error": f"rST file not found: {source_file}",
-            })
-            continue
+            raise RstRenderError(f"rST file not found: {source_file}")
 
-        try:
-            output = render_single_file(source_file, image_base_slug, strict)
-            results.append({
-                "file": str(source_file),
-                "ok": True,
-                "result": output,
-            })
-        except (RstRenderError, OSError, ValueError, KeyError, AttributeError) as exc:
-            results.append({
-                "file": str(source_file),
-                "ok": False,
-                "error": str(exc),
-            })
+        output = render_single_file(source_file, image_base_slug, strict)
+        results.append({
+            "file": str(source_file),
+            "ok": True,
+            "result": output,
+        })
 
     return results
 

--- a/scripts/render-rst.py
+++ b/scripts/render-rst.py
@@ -194,18 +194,39 @@ def register_passthrough_roles(warnings: list[str]) -> None:
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Render a single rST file to JSON via docutils.")
-    parser.add_argument("--file", required=True, help="Absolute or relative path to the .rst file")
+    parser.add_argument("--file", help="Absolute or relative path to the .rst file")
     parser.add_argument(
         "--image-base-slug",
-        required=True,
         help="Public-relative base slug for local assets, for example posts/my-post",
+    )
+    parser.add_argument(
+        "--batch-stdin",
+        action="store_true",
+        help="Read a JSON array of batch render entries from stdin",
     )
     parser.add_argument(
         "--strict",
         action="store_true",
         help="Fail on missing local assets instead of reporting them in the output",
     )
-    return parser.parse_args()
+    args = parser.parse_args()
+
+    if args.batch_stdin:
+        if args.file or args.image_base_slug:
+            parser.error("--batch-stdin cannot be combined with --file or --image-base-slug")
+        return args
+
+    if not args.file or not args.image_base_slug:
+        parser.error("--file and --image-base-slug are required unless --batch-stdin is used")
+
+    return args
+
+
+def resolve_source_file(raw_file: str) -> Path:
+    source_file = Path(raw_file).expanduser()
+    if not source_file.is_absolute():
+        source_file = (Path.cwd() / source_file).resolve()
+    return source_file
 
 
 def normalize_metadata_value(key: str, value: str) -> Any:
@@ -443,18 +464,87 @@ def build_output(document: Any, source: str, source_file: Path, image_base_slug:
     }
 
 
+def render_single_file(source_file: Path, image_base_slug: str, strict: bool) -> dict[str, Any]:
+    from docutils.core import publish_doctree
+
+    warnings: list[str] = []
+    register_doc_role(source_file, warnings)
+    register_passthrough_roles(warnings)
+    source = source_file.read_text(encoding="utf-8")
+    document = publish_doctree(
+        source=source,
+        settings_overrides={
+            "report_level": 2,
+            "halt_level": 5,
+            "file_insertion_enabled": False,
+            "raw_enabled": False,
+        },
+    )
+    remove_system_messages(document)
+    output = build_output(document, source, source_file, image_base_slug, warnings)
+
+    if strict:
+        missing = [asset for asset in output["assets"] if not asset["exists"]]
+        if missing:
+            first = missing[0]
+            raise RstRenderError(
+                f'Missing local asset "{first["original"]}" in {source_file}'
+            )
+
+    return output
+
+
+def render_batch(strict: bool) -> list[dict[str, Any]]:
+    raw_input = sys.stdin.read()
+    try:
+        entries = json.loads(raw_input)
+    except json.JSONDecodeError as exc:
+        raise RstRenderError(f"Invalid batch JSON: {exc.msg}") from exc
+
+    if not isinstance(entries, list):
+        raise RstRenderError("Invalid batch JSON: expected an array.")
+
+    results: list[dict[str, Any]] = []
+    for entry in entries:
+        if not isinstance(entry, dict):
+            raise RstRenderError("Invalid batch entry: expected an object.")
+
+        raw_file = entry.get("file")
+        image_base_slug = entry.get("imageBaseSlug")
+        if not isinstance(raw_file, str) or not isinstance(image_base_slug, str):
+            raise RstRenderError("Invalid batch entry: missing file or imageBaseSlug.")
+
+        source_file = resolve_source_file(raw_file)
+        if not source_file.exists():
+            results.append({
+                "file": str(source_file),
+                "ok": False,
+                "error": f"rST file not found: {source_file}",
+            })
+            continue
+
+        try:
+            output = render_single_file(source_file, image_base_slug, strict)
+            results.append({
+                "file": str(source_file),
+                "ok": True,
+                "result": output,
+            })
+        except (RstRenderError, OSError, ValueError, KeyError, AttributeError) as exc:
+            results.append({
+                "file": str(source_file),
+                "ok": False,
+                "error": str(exc),
+            })
+
+    return results
+
+
 def main() -> int:
     args = parse_args()
-    source_file = Path(args.file).expanduser()
-    if not source_file.is_absolute():
-        source_file = (Path.cwd() / source_file).resolve()
-
-    if not source_file.exists():
-        print(f"rST file not found: {source_file}", file=sys.stderr)
-        return 1
 
     try:
-        from docutils.core import publish_doctree
+        from docutils.core import publish_doctree  # noqa: F401
     except ImportError:
         print(
             "Missing Python dependency: docutils. Install it with `python3 -m pip install docutils`.",
@@ -463,31 +553,16 @@ def main() -> int:
         return 1
 
     try:
-        warnings: list[str] = []
-        register_doc_role(source_file, warnings)
-        register_passthrough_roles(warnings)
-        source = source_file.read_text(encoding="utf-8")
-        document = publish_doctree(
-            source=source,
-            settings_overrides={
-                "report_level": 2,
-                "halt_level": 5,
-                "file_insertion_enabled": False,
-                "raw_enabled": False,
-            },
-        )
-        remove_system_messages(document)
-        output = build_output(document, source, source_file, args.image_base_slug, warnings)
+        if args.batch_stdin:
+            print(json.dumps(render_batch(args.strict), ensure_ascii=False))
+            return 0
 
-        if args.strict:
-            missing = [asset for asset in output["assets"] if not asset["exists"]]
-            if missing:
-                first = missing[0]
-                raise RstRenderError(
-                    f'Missing local asset "{first["original"]}" in {source_file}'
-                )
+        source_file = resolve_source_file(args.file)
+        if not source_file.exists():
+            print(f"rST file not found: {source_file}", file=sys.stderr)
+            return 1
 
-        print(json.dumps(output, ensure_ascii=False))
+        print(json.dumps(render_single_file(source_file, args.image_base_slug, args.strict), ensure_ascii=False))
         return 0
     except RstRenderError as exc:
         print(str(exc), file=sys.stderr)

--- a/src/lib/markdown.ts
+++ b/src/lib/markdown.ts
@@ -171,12 +171,19 @@ const seriesAuthorsCache = new Map<string, Map<string, string[] | null>>();
 const seriesTitleCache = new Map<string, Map<string, string | undefined>>();
 let pythonRstRendererAvailable: boolean | null = null;
 
-const PYTHON_RUNTIME_UNAVAILABLE_PATTERN = /docutils|No module named|not found|interpreter/i;
+const PYTHON_RUNTIME_UNAVAILABLE_PATTERN = /docutils|No module named|python(?:3)? .*not found|interpreter not found|ENOENT.*python/i;
 
 function isPythonRuntimeUnavailable(error: unknown): boolean {
   if (!(error instanceof Error)) return false;
   if (error.message.includes('__RST_FALLBACK__')) return true;
+  if (error.message.includes('rST file not found')) return false;
   return PYTHON_RUNTIME_UNAVAILABLE_PATTERN.test(error.message);
+}
+
+function getRstImageBaseSlug(fullPath: string, slug: string): string {
+  const isRootFlatPost = path.basename(fullPath) !== 'index.rst' &&
+    path.dirname(fullPath) === contentDirectory;
+  return isRootFlatPost ? 'posts' : `posts/${slug}`;
 }
 
 function shouldUsePythonRstRenderer(): boolean {
@@ -584,9 +591,7 @@ function parseRstFile(
   seriesName?: string,
   preRendered?: RenderedRstDocument,
 ): PostData {
-  const isRootFlatPost = path.basename(fullPath) !== 'index.rst' &&
-    path.dirname(fullPath) === contentDirectory;
-  const imageBaseSlug = isRootFlatPost ? 'posts' : `posts/${slug}`;
+  const imageBaseSlug = getRstImageBaseSlug(fullPath, slug);
   const fileContents = fs.readFileSync(fullPath, 'utf8');
 
   let parsedTitle: string;
@@ -773,10 +778,7 @@ export function getAllPosts(): PostData[] {
         batchRenderedByFile = renderRstFilesBatch(
           pendingRstPosts.map(entry => ({
             file: entry.fullPath,
-            imageBaseSlug: path.basename(entry.fullPath) !== 'index.rst' &&
-              path.dirname(entry.fullPath) === contentDirectory
-              ? 'posts'
-              : `posts/${entry.slug}`,
+            imageBaseSlug: getRstImageBaseSlug(entry.fullPath, entry.slug),
           }))
         );
         pythonRstRendererAvailable = true;

--- a/src/lib/markdown.ts
+++ b/src/lib/markdown.ts
@@ -6,7 +6,7 @@ import GithubSlugger from 'github-slugger';
 import { z } from 'zod';
 import { getPostUrl } from './urls';
 import { parseRstDocument } from './rst';
-import { renderRstFile } from './rst-renderer';
+import { renderRstFile, renderRstFilesBatch, type RenderedRstDocument } from './rst-renderer';
 
 const contentDirectory = path.join(process.cwd(), 'content', 'posts');
 const pagesDirectory = path.join(process.cwd(), 'content');
@@ -141,6 +141,13 @@ interface SeriesContentEntry {
   fullPath: string;
   slug: string;
   dateFromFileName?: string;
+}
+
+interface PendingRstPostEntry {
+  fullPath: string;
+  slug: string;
+  dateFromFileName?: string;
+  seriesSlug?: string;
 }
 
 function getCacheEnvKey(): string {
@@ -562,7 +569,13 @@ function parseMarkdownFile(fullPath: string, slug: string, dateFromFileName?: st
   };
 }
 
-function parseRstFile(fullPath: string, slug: string, dateFromFileName?: string, seriesName?: string): PostData {
+function parseRstFile(
+  fullPath: string,
+  slug: string,
+  dateFromFileName?: string,
+  seriesName?: string,
+  preRendered?: RenderedRstDocument,
+): PostData {
   const isRootFlatPost = path.basename(fullPath) !== 'index.rst' &&
     path.dirname(fullPath) === contentDirectory;
   const imageBaseSlug = isRootFlatPost ? 'posts' : `posts/${slug}`;
@@ -583,7 +596,17 @@ function parseRstFile(fullPath: string, slug: string, dateFromFileName?: string,
   };
 
   try {
-    if (shouldUsePythonRstRenderer() && pythonRstRendererAvailable !== false) {
+    if (preRendered) {
+      const rendered = preRendered;
+      parsedTitle = rendered.title;
+      parsedBody = rendered.text;
+      parsedText = rendered.text;
+      parsedHeadings = rendered.headings;
+      parsedExcerpt = rendered.excerpt;
+      parsedReadingTime = rendered.readingTime;
+      parsedHtml = rendered.html;
+      data = rendered.metadata;
+    } else if (shouldUsePythonRstRenderer() && pythonRstRendererAvailable !== false) {
       const rendered = renderRstFile(fullPath, imageBaseSlug);
       pythonRstRendererAvailable = true;
       parsedTitle = rendered.title;
@@ -681,6 +704,7 @@ export function getAllPosts(): PostData[] {
   if (cached) return cached;
 
   const allPostsData: PostData[] = [];
+  const pendingRstPosts: PendingRstPostEntry[] = [];
 
   // Helper to process a directory
   const processDirectory = (dir: string, isSeriesDir: boolean = false) => {
@@ -704,11 +728,16 @@ export function getAllPosts(): PostData[] {
           if (!indexInfo) return;
 
           getSeriesContentEntries(seriesSlug).forEach(entry => {
-            allPostsData.push(
-              indexInfo.format === 'rst'
-                ? parseRstFile(entry.fullPath, entry.slug, entry.dateFromFileName, seriesSlug)
-                : parseMarkdownFile(entry.fullPath, entry.slug, entry.dateFromFileName, seriesSlug)
-            );
+            if (indexInfo.format === 'rst') {
+              pendingRstPosts.push({
+                fullPath: entry.fullPath,
+                slug: entry.slug,
+                dateFromFileName: entry.dateFromFileName,
+                seriesSlug,
+              });
+            } else {
+              allPostsData.push(parseMarkdownFile(entry.fullPath, entry.slug, entry.dateFromFileName, seriesSlug));
+            }
           });
           return;
         }
@@ -733,6 +762,43 @@ export function getAllPosts(): PostData[] {
 
   processDirectory(contentDirectory);
   processDirectory(seriesDirectory, true);
+
+  if (pendingRstPosts.length > 0) {
+    let batchRenderedByFile: Map<string, RenderedRstDocument> | null = null;
+
+    if (shouldUsePythonRstRenderer() && pythonRstRendererAvailable !== false) {
+      try {
+        batchRenderedByFile = renderRstFilesBatch(
+          pendingRstPosts.map(entry => ({
+            file: entry.fullPath,
+            imageBaseSlug: path.basename(entry.fullPath) !== 'index.rst' &&
+              path.dirname(entry.fullPath) === contentDirectory
+              ? 'posts'
+              : `posts/${entry.slug}`,
+          }))
+        );
+        pythonRstRendererAvailable = true;
+      } catch (error) {
+        if (error instanceof Error && /docutils|No module named|not found|interpreter/i.test(error.message)) {
+          pythonRstRendererAvailable = false;
+        } else {
+          throw error;
+        }
+      }
+    }
+
+    pendingRstPosts.forEach(entry => {
+      allPostsData.push(
+        parseRstFile(
+          entry.fullPath,
+          entry.slug,
+          entry.dateFromFileName,
+          entry.seriesSlug,
+          batchRenderedByFile?.get(entry.fullPath),
+        )
+      );
+    });
+  }
 
   const result = allPostsData
     .filter(post => {

--- a/src/lib/markdown.ts
+++ b/src/lib/markdown.ts
@@ -171,6 +171,14 @@ const seriesAuthorsCache = new Map<string, Map<string, string[] | null>>();
 const seriesTitleCache = new Map<string, Map<string, string | undefined>>();
 let pythonRstRendererAvailable: boolean | null = null;
 
+const PYTHON_RUNTIME_UNAVAILABLE_PATTERN = /docutils|No module named|not found|interpreter/i;
+
+function isPythonRuntimeUnavailable(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+  if (error.message.includes('__RST_FALLBACK__')) return true;
+  return PYTHON_RUNTIME_UNAVAILABLE_PATTERN.test(error.message);
+}
+
 function shouldUsePythonRstRenderer(): boolean {
   if (process.env.AMYTIS_ENABLE_PYTHON_RST === '1') return true;
   if (process.env.AMYTIS_ENABLE_PYTHON_RST === '0') return false;
@@ -589,12 +597,6 @@ function parseRstFile(
   let parsedReadingTime: string;
   let parsedHtml: string | undefined;
   let data: ReturnType<typeof parseRstDocument>['metadata'];
-  const isPythonRuntimeUnavailable = (error: unknown): boolean => {
-    if (!(error instanceof Error)) return false;
-    if (error.message.includes('__RST_FALLBACK__')) return true;
-    return /docutils|No module named|not found|interpreter/i.test(error.message);
-  };
-
   try {
     if (preRendered) {
       const rendered = preRendered;
@@ -779,7 +781,7 @@ export function getAllPosts(): PostData[] {
         );
         pythonRstRendererAvailable = true;
       } catch (error) {
-        if (error instanceof Error && /docutils|No module named|not found|interpreter/i.test(error.message)) {
+        if (isPythonRuntimeUnavailable(error)) {
           pythonRstRendererAvailable = false;
         } else {
           throw error;

--- a/src/lib/rst-renderer.ts
+++ b/src/lib/rst-renderer.ts
@@ -37,7 +37,24 @@ export interface RenderedRstDocument {
   warnings: string[];
 }
 
+export interface PythonRstBatchEntry {
+  file: string;
+  imageBaseSlug: string;
+}
+
+interface PythonRstBatchResponseItem {
+  file: string;
+  ok: boolean;
+  result?: PythonRstRenderResult;
+  error?: string;
+}
+
 const rstRenderCache = new Map<string, RenderedRstDocument>();
+
+function getRenderCacheKey(filePath: string, imageBaseSlug: string): string {
+  const stats = fs.statSync(filePath);
+  return `${getPythonExecutableForRstRenderer()}::${filePath}::${imageBaseSlug}::${stats.mtimeMs}::${stats.size}`;
+}
 
 function getPythonExecutableForRstRenderer(): string {
   return process.env.AMYTIS_RST_PYTHON || 'python3';
@@ -271,9 +288,62 @@ export function runPythonRstRenderer(filePath: string, imageBaseSlug: string): P
   }
 }
 
+export function runPythonRstRendererBatch(entries: PythonRstBatchEntry[]): Map<string, PythonRstRenderResult> {
+  if (entries.length === 0) return new Map();
+
+  const scriptPath = path.join(process.cwd(), 'scripts', 'render-rst.py');
+  const pythonExecutable = getPythonExecutableForRstRenderer();
+  const result = spawnSync(pythonExecutable, [
+    scriptPath,
+    '--batch-stdin',
+    '--strict',
+  ], {
+    encoding: 'utf8',
+    input: JSON.stringify(entries),
+  });
+
+  if (result.error) {
+    throw new RstParseError(`Failed to run Python rST renderer batch: ${result.error.message}`);
+  }
+
+  if (result.status !== 0) {
+    throw new RstParseError(
+      result.stderr.trim() || `Python rST renderer batch exited with status ${result.status}.`
+    );
+  }
+
+  let parsed: PythonRstBatchResponseItem[];
+  try {
+    parsed = JSON.parse(result.stdout) as PythonRstBatchResponseItem[];
+  } catch (error) {
+    throw new RstParseError(
+      `Invalid JSON from Python rST renderer batch: ${error instanceof Error ? error.message : String(error)}`
+    );
+  }
+
+  if (!Array.isArray(parsed)) {
+    throw new RstParseError('Invalid batch response from Python rST renderer: expected an array.');
+  }
+
+  const renderedByFile = new Map<string, PythonRstRenderResult>();
+  for (const item of parsed) {
+    if (!item || typeof item.file !== 'string' || typeof item.ok !== 'boolean') {
+      throw new RstParseError('Invalid batch response item from Python rST renderer.');
+    }
+    if (!item.ok) {
+      throw new RstParseError(item.error || `Python rST renderer batch failed for ${item.file}.`);
+    }
+    if (!item.result) {
+      throw new RstParseError(`Python rST renderer batch returned no result for ${item.file}.`);
+    }
+    renderedByFile.set(item.file, item.result);
+  }
+
+  return renderedByFile;
+}
+
 export function renderRstFile(filePath: string, imageBaseSlug: string): RenderedRstDocument {
-  const stats = fs.statSync(filePath);
-  const cacheKey = `${getPythonExecutableForRstRenderer()}::${filePath}::${imageBaseSlug}::${stats.mtimeMs}::${stats.size}`;
+  const cacheKey = getRenderCacheKey(filePath, imageBaseSlug);
   const cached = rstRenderCache.get(cacheKey);
   if (cached) {
     return cached;
@@ -297,4 +367,48 @@ export function renderRstFile(filePath: string, imageBaseSlug: string): Rendered
 
   rstRenderCache.set(cacheKey, rendered);
   return rendered;
+}
+
+export function renderRstFilesBatch(entries: PythonRstBatchEntry[]): Map<string, RenderedRstDocument> {
+  const renderedByFile = new Map<string, RenderedRstDocument>();
+  const uncachedEntries: PythonRstBatchEntry[] = [];
+
+  for (const entry of entries) {
+    const cacheKey = getRenderCacheKey(entry.file, entry.imageBaseSlug);
+    const cached = rstRenderCache.get(cacheKey);
+    if (cached) {
+      renderedByFile.set(entry.file, cached);
+      continue;
+    }
+    uncachedEntries.push(entry);
+  }
+
+  if (uncachedEntries.length === 0) {
+    return renderedByFile;
+  }
+
+  const batchResults = runPythonRstRendererBatch(uncachedEntries);
+  for (const entry of uncachedEntries) {
+    const result = batchResults.get(entry.file);
+    if (!result) {
+      throw new RstParseError(`Python rST renderer batch returned no result for ${entry.file}.`);
+    }
+    validatePythonRstResult(result, entry.file);
+    const metadata = normalizePythonRstMetadata(result.metadata);
+    const rendered: RenderedRstDocument = {
+      title: result.title,
+      html: result.html,
+      text: result.text,
+      headings: result.headings,
+      metadata,
+      excerpt: metadata.excerpt || generateExcerptFromText(result.text),
+      readingTime: calculateReadingTimeFromText(result.text),
+      assets: result.assets ?? [],
+      warnings: (result.warnings ?? []).map((warning) => String(warning)),
+    };
+    rstRenderCache.set(getRenderCacheKey(entry.file, entry.imageBaseSlug), rendered);
+    renderedByFile.set(entry.file, rendered);
+  }
+
+  return renderedByFile;
 }

--- a/src/lib/rst-renderer.ts
+++ b/src/lib/rst-renderer.ts
@@ -1,4 +1,5 @@
 import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
 import path from 'node:path';
 import { RstMetadata, RstParseError } from './rst';
 
@@ -35,6 +36,8 @@ export interface RenderedRstDocument {
   assets: PythonRstAsset[];
   warnings: string[];
 }
+
+const rstRenderCache = new Map<string, RenderedRstDocument>();
 
 function getPythonExecutableForRstRenderer(): string {
   return process.env.AMYTIS_RST_PYTHON || 'python3';
@@ -269,11 +272,18 @@ export function runPythonRstRenderer(filePath: string, imageBaseSlug: string): P
 }
 
 export function renderRstFile(filePath: string, imageBaseSlug: string): RenderedRstDocument {
+  const stats = fs.statSync(filePath);
+  const cacheKey = `${getPythonExecutableForRstRenderer()}::${filePath}::${imageBaseSlug}::${stats.mtimeMs}::${stats.size}`;
+  const cached = rstRenderCache.get(cacheKey);
+  if (cached) {
+    return cached;
+  }
+
   const result = runPythonRstRenderer(filePath, imageBaseSlug);
   validatePythonRstResult(result, filePath);
   const metadata = normalizePythonRstMetadata(result.metadata);
 
-  return {
+  const rendered = {
     title: result.title,
     html: result.html,
     text: result.text,
@@ -284,4 +294,7 @@ export function renderRstFile(filePath: string, imageBaseSlug: string): Rendered
     assets: result.assets ?? [],
     warnings: (result.warnings ?? []).map((warning) => String(warning)),
   };
+
+  rstRenderCache.set(cacheKey, rendered);
+  return rendered;
 }


### PR DESCRIPTION
## Summary

This PR makes two incremental build-path optimizations for the rST/docutils flow:

- cache rendered rST documents in-process by file state
- batch rST post rendering during `getAllPosts()` so many `.rst` posts can be rendered in a single Python invocation instead of one process per file

It also removes one avoidable linear scan in the knowledge-graph script.

## What Changed

- add in-process caching in `src/lib/rst-renderer.ts`
- add batch mode to `scripts/render-rst.py`
- add batch rendering support to `src/lib/rst-renderer.ts`
- use the batch rST path from `getAllPosts()` in `src/lib/markdown.ts`
- replace `flows.find(...)` with a `Map` lookup in `scripts/generate-knowledge-graph.ts`

## Why

`bun run build:dev` is still slow after the docutils-backed rST work landed. A stage-by-stage timing pass showed:

- `bun scripts/copy-assets.ts`: ~2.7s
- `bun run build:graph`: ~0.4s
- `bunx pagefind --site out --output-path public/pagefind`: ~10.9s
- `next build`: overwhelmingly dominant

So the main target here is reducing avoidable work in the content/render path used during static generation, especially repeated Python startup for rST rendering.

## Scope

This PR is an incremental optimization, not a full fix for the remaining `next build` time. The single-file Python path stays in place for simpler call sites and fallback behavior.

## Validation

Ran:
- `bun test src/lib/rst-renderer.test.ts tests/integration/series.test.ts`
- `bun run lint`
- `bun run build:graph`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added batch rendering mode (stdin JSON) with per-file results and improved CLI options.
  * Added filesystem caching for rendered documents and faster wikilink resolution for large content sets.
  * Improved path expansion (~/relative → absolute) and per-entry handling in batch runs.

* **Bug Fixes**
  * Better validation and error reporting for missing/invalid inputs and when the Python renderer is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->