### PR TITLE
fix: improve rst runtime rendering and series ordering

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,6 +267,7 @@ export AMYTIS_RST_PYTHON=/absolute/path/to/python
 Current behavior:
 
 - `index.rst` or `README.rst` makes the whole series rST-only.
+- For rST series ordering, explicit `:posts:` metadata takes precedence. If `:posts:` is absent, Amytis uses simple local `.. toctree::` entry order from the series index. If neither exists, the series falls back to the existing date-based sort.
 - rST assets such as `.. image::` and `.. figure::` are resolved relative to the source file and rewritten to the site asset paths.
 - Supported legacy roles such as `:doc:`, `:ref:`, `:numref:`, `:math:`, and `:dtag:` are either rendered directly or degraded into readable inline output instead of docutils error blocks.
 - Top-of-file docinfo metadata is parsed into Amytis metadata, but it is not rendered at the top of blog-style article HTML.

--- a/README.zh.md
+++ b/README.zh.md
@@ -273,6 +273,7 @@ export AMYTIS_RST_PYTHON=/absolute/path/to/python
 当前行为：
 
 - `index.rst` 或 `README.rst` 会让整个系列进入 rST 模式。
+- 对于 rST 系列文章顺序，显式的 `:posts:` 元数据优先级最高；如果没有 `:posts:`，Amytis 会使用系列入口文件中简单本地 `.. toctree::` 条目的顺序；如果两者都没有，则回退到现有的基于日期排序。
 - `.. image::`、`.. figure::` 等资源路径会相对源文件解析，并重写为站点可用的静态资源路径。
 - `:doc:`、`:ref:`、`:numref:`、`:math:`、`:dtag:` 等常见 legacy role 会尽量直接渲染；无法完整支持时也会降级为可读的内联输出，而不是 docutils 报错块。
 - 文件顶部的 docinfo 元数据会被解析为 Amytis 元数据，但不会再渲染为文章顶部的作者/版本信息块。

--- a/content/series/rst-toctree-precedence/first-post.rst
+++ b/content/series/rst-toctree-precedence/first-post.rst
@@ -1,0 +1,6 @@
+First Post
+==========
+
+:date: 2024-01-01
+
+This post should remain first because explicit posts metadata wins.

--- a/content/series/rst-toctree-precedence/index.rst
+++ b/content/series/rst-toctree-precedence/index.rst
@@ -1,0 +1,12 @@
+Rst Toctree Precedence Series
+=============================
+
+:excerpt: Explicit posts metadata should override toctree order.
+:sort: manual
+:posts: first-post, second-post
+
+.. toctree::
+   :maxdepth: 1
+
+   second-post
+   first-post

--- a/content/series/rst-toctree-precedence/second-post.rst
+++ b/content/series/rst-toctree-precedence/second-post.rst
@@ -1,0 +1,6 @@
+Second Post
+===========
+
+:date: 2024-01-02
+
+This post should remain second because explicit posts metadata wins.

--- a/content/series/rst-toctree/first-post.rst
+++ b/content/series/rst-toctree/first-post.rst
@@ -1,0 +1,6 @@
+First Post
+==========
+
+:date: 2024-01-01
+
+This post appears second in the toctree order.

--- a/content/series/rst-toctree/index.rst
+++ b/content/series/rst-toctree/index.rst
@@ -1,0 +1,10 @@
+Rst Toctree Series
+==================
+
+:excerpt: Legacy series order derived from toctree.
+
+.. toctree::
+   :maxdepth: 1
+
+   second-post
+   first-post

--- a/content/series/rst-toctree/second-post.rst
+++ b/content/series/rst-toctree/second-post.rst
@@ -1,0 +1,6 @@
+Second Post
+===========
+
+:date: 2024-01-02
+
+This post appears first in the toctree order.

--- a/package.json
+++ b/package.json
@@ -13,9 +13,9 @@
   "private": false,
   "packageManager": "bun@1.3.4",
   "scripts": {
-    "dev": "next dev",
-    "build": "bun scripts/copy-assets.ts && bun run build:graph && next build && next-image-export-optimizer && pagefind --site out",
-    "build:dev": "bun scripts/copy-assets.ts && bun run build:graph && next build && pagefind --site out --output-path public/pagefind",
+    "dev": "bun scripts/run-with-rst-python.ts next dev",
+    "build": "bun scripts/copy-assets.ts && bun run build:graph && bun scripts/run-with-rst-python.ts next build && next-image-export-optimizer && pagefind --site out",
+    "build:dev": "bun scripts/copy-assets.ts && bun run build:graph && bun scripts/run-with-rst-python.ts next build && pagefind --site out --output-path public/pagefind",
     "build:graph": "NODE_ENV=production bun scripts/generate-knowledge-graph.ts",
     "validate": "bun run lint && bun run test && bun run build:dev",
     "clean": "rm -rf .next out public/posts public/books public/flows",

--- a/scripts/run-with-rst-python.ts
+++ b/scripts/run-with-rst-python.ts
@@ -11,7 +11,12 @@ if (!command) {
 
 const env = { ...process.env };
 if (!env.AMYTIS_RST_PYTHON) {
-  const localPython = path.join(process.cwd(), '.venv-rst', 'bin', 'python');
+  const localPython = path.join(
+    process.cwd(),
+    '.venv-rst',
+    process.platform === 'win32' ? 'Scripts' : 'bin',
+    process.platform === 'win32' ? 'python.exe' : 'python',
+  );
   if (fs.existsSync(localPython)) {
     env.AMYTIS_RST_PYTHON = localPython;
   }
@@ -20,6 +25,7 @@ if (!env.AMYTIS_RST_PYTHON) {
 const child = spawn(command, args, {
   stdio: 'inherit',
   env,
+  shell: process.platform === 'win32',
 });
 
 child.on('exit', (code, signal) => {

--- a/scripts/run-with-rst-python.ts
+++ b/scripts/run-with-rst-python.ts
@@ -1,0 +1,36 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { spawn } from 'node:child_process';
+
+const [command, ...args] = Bun.argv.slice(2);
+
+if (!command) {
+  console.error('Missing command to run.');
+  process.exit(1);
+}
+
+const env = { ...process.env };
+if (!env.AMYTIS_RST_PYTHON) {
+  const localPython = path.join(process.cwd(), '.venv-rst', 'bin', 'python');
+  if (fs.existsSync(localPython)) {
+    env.AMYTIS_RST_PYTHON = localPython;
+  }
+}
+
+const child = spawn(command, args, {
+  stdio: 'inherit',
+  env,
+});
+
+child.on('exit', (code, signal) => {
+  if (signal) {
+    process.kill(process.pid, signal);
+    return;
+  }
+  process.exit(code ?? 1);
+});
+
+child.on('error', (error) => {
+  console.error(error.message);
+  process.exit(1);
+});

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -533,10 +533,22 @@ body {
 .rst-rendered pre.literal-block,
 .rst-rendered pre.code.literal-block {
   overflow-x: auto;
-  border: 1px solid color-mix(in srgb, var(--muted) 18%, transparent);
+  border: 1px solid color-mix(in srgb, var(--muted) 28%, transparent);
   border-radius: 0.875rem;
-  background: color-mix(in srgb, var(--foreground) 4%, var(--background));
+  background: color-mix(in srgb, var(--heading) 7%, var(--background));
   padding: 1rem 1.25rem;
+  color: var(--heading);
+  font-size: 0.95rem;
+  line-height: 1.7;
+  box-shadow: inset 0 1px 0 color-mix(in srgb, white 60%, transparent);
+}
+
+.dark .rst-rendered pre.literal-block,
+.dark .rst-rendered pre.code.literal-block {
+  border-color: color-mix(in srgb, var(--muted) 22%, transparent);
+  background: color-mix(in srgb, var(--foreground) 9%, var(--background));
+  color: var(--foreground);
+  box-shadow: inset 0 1px 0 color-mix(in srgb, white 5%, transparent);
 }
 
 .rst-rendered pre.code.literal-block code {

--- a/src/lib/markdown.ts
+++ b/src/lib/markdown.ts
@@ -741,7 +741,9 @@ function parseRstFile(
   const toctreePosts = isSeriesIndexRst(fullPath, slug, seriesName)
     ? extractRstToctreePosts(fileContents)
     : [];
-  const seriesPosts = data.posts && data.posts.length > 0 ? data.posts : (toctreePosts.length > 0 ? toctreePosts : undefined);
+  const seriesPosts = data.posts && data.posts.length > 0
+    ? data.posts
+    : ((data.sort === undefined || data.sort === 'manual') && toctreePosts.length > 0 ? toctreePosts : undefined);
   const sort = data.sort ?? (seriesPosts ? 'manual' : 'date-desc');
 
   return {

--- a/src/lib/markdown.ts
+++ b/src/lib/markdown.ts
@@ -186,6 +186,72 @@ function getRstImageBaseSlug(fullPath: string, slug: string): string {
   return isRootFlatPost ? 'posts' : `posts/${slug}`;
 }
 
+function isSeriesIndexRst(fullPath: string, slug: string, seriesName?: string): boolean {
+  return Boolean(
+    seriesName &&
+    slug === seriesName &&
+    (path.basename(fullPath) === 'index.rst' || path.basename(fullPath) === 'README.rst')
+  );
+}
+
+function slugFromRstToctreeTarget(target: string): string | null {
+  const trimmed = target.trim();
+  if (!trimmed || trimmed.startsWith(':')) return null;
+  if (/^[a-z]+:\/\//i.test(trimmed) || trimmed.startsWith('/')) return null;
+
+  const withoutAnchor = trimmed.split('#')[0]?.split('?')[0]?.trim();
+  if (!withoutAnchor) return null;
+
+  const normalized = withoutAnchor.replace(/\\/g, '/').replace(/^\.\//, '').replace(/\/+$/, '');
+  if (!normalized || normalized.startsWith('../')) return null;
+
+  const withoutExt = normalized.replace(/\.rst$/i, '');
+  const parts = withoutExt.split('/').filter(Boolean);
+  if (parts.length === 0) return null;
+
+  const last = parts[parts.length - 1];
+  if (last === 'index' || last === 'README') {
+    return parts.length > 1 ? parts[parts.length - 2] : null;
+  }
+
+  return last;
+}
+
+function extractRstToctreePosts(source: string): string[] {
+  const lines = source.replace(/\r\n?/g, '\n').split('\n');
+  const posts: string[] = [];
+  const seen = new Set<string>();
+
+  for (let i = 0; i < lines.length; i++) {
+    if (!/^\s*\.\.\s+toctree::\s*$/.test(lines[i])) continue;
+
+    i++;
+    while (i < lines.length) {
+      const line = lines[i];
+      if (!line.trim()) {
+        i++;
+        continue;
+      }
+      if (!/^\s+/.test(line)) {
+        i--;
+        break;
+      }
+
+      const trimmed = line.trim();
+      if (!trimmed.startsWith(':')) {
+        const slug = slugFromRstToctreeTarget(trimmed);
+        if (slug && !seen.has(slug)) {
+          seen.add(slug);
+          posts.push(slug);
+        }
+      }
+      i++;
+    }
+  }
+
+  return posts;
+}
+
 function shouldUsePythonRstRenderer(): boolean {
   if (process.env.AMYTIS_ENABLE_PYTHON_RST === '1') return true;
   if (process.env.AMYTIS_ENABLE_PYTHON_RST === '0') return false;
@@ -672,6 +738,12 @@ function parseRstFile(
     coverImage = `/${imageBaseSlug}/${cleanPath}`;
   }
 
+  const toctreePosts = isSeriesIndexRst(fullPath, slug, seriesName)
+    ? extractRstToctreePosts(fileContents)
+    : [];
+  const seriesPosts = data.posts && data.posts.length > 0 ? data.posts : (toctreePosts.length > 0 ? toctreePosts : undefined);
+  const sort = data.sort ?? (seriesPosts ? 'manual' : 'date-desc');
+
   return {
     slug,
     title: parsedTitle,
@@ -685,8 +757,8 @@ function parseRstFile(
     series: effectiveSeriesSlug,
     seriesTitle: effectiveSeriesSlug ? getSeriesTitle(effectiveSeriesSlug) : undefined,
     coverImage,
-    sort: data.sort ?? 'date-desc',
-    posts: data.posts,
+    sort,
+    posts: seriesPosts,
     type: data.type,
     featured: data.featured ?? false,
     pinned: data.pinned ?? false,

--- a/src/lib/rst-renderer.ts
+++ b/src/lib/rst-renderer.ts
@@ -50,6 +50,7 @@ interface PythonRstBatchResponseItem {
 }
 
 const rstRenderCache = new Map<string, RenderedRstDocument>();
+const PYTHON_RENDERER_MAX_BUFFER = 1024 * 1024 * 128;
 
 function getRenderCacheKey(filePath: string, imageBaseSlug: string): string {
   const stats = fs.statSync(filePath);
@@ -267,6 +268,7 @@ export function runPythonRstRenderer(filePath: string, imageBaseSlug: string): P
     '--strict',
   ], {
     encoding: 'utf8',
+    maxBuffer: PYTHON_RENDERER_MAX_BUFFER,
   });
 
   if (result.error) {
@@ -300,6 +302,7 @@ export function runPythonRstRendererBatch(entries: PythonRstBatchEntry[]): Map<s
   ], {
     encoding: 'utf8',
     input: JSON.stringify(entries),
+    maxBuffer: PYTHON_RENDERER_MAX_BUFFER,
   });
 
   if (result.error) {
@@ -336,7 +339,7 @@ export function runPythonRstRendererBatch(entries: PythonRstBatchEntry[]): Map<s
     if (!item.result) {
       throw new RstParseError(`Python rST renderer batch returned no result for ${item.file}.`);
     }
-    renderedByFile.set(item.file, item.result);
+    renderedByFile.set(path.resolve(item.file), item.result);
   }
 
   return renderedByFile;
@@ -389,7 +392,7 @@ export function renderRstFilesBatch(entries: PythonRstBatchEntry[]): Map<string,
 
   const batchResults = runPythonRstRendererBatch(uncachedEntries);
   for (const entry of uncachedEntries) {
-    const result = batchResults.get(entry.file);
+    const result = batchResults.get(path.resolve(entry.file));
     if (!result) {
       throw new RstParseError(`Python rST renderer batch returned no result for ${entry.file}.`);
     }

--- a/src/lib/rst-renderer.ts
+++ b/src/lib/rst-renderer.ts
@@ -52,6 +52,14 @@ interface PythonRstBatchResponseItem {
 const rstRenderCache = new Map<string, RenderedRstDocument>();
 const PYTHON_RENDERER_MAX_BUFFER = 1024 * 1024 * 128;
 
+function canonicalizeSourcePath(filePath: string): string {
+  try {
+    return fs.realpathSync(filePath);
+  } catch {
+    return path.resolve(filePath);
+  }
+}
+
 function getRenderCacheKey(filePath: string, imageBaseSlug: string): string {
   const stats = fs.statSync(filePath);
   return `${getPythonExecutableForRstRenderer()}::${filePath}::${imageBaseSlug}::${stats.mtimeMs}::${stats.size}`;
@@ -339,7 +347,7 @@ export function runPythonRstRendererBatch(entries: PythonRstBatchEntry[]): Map<s
     if (!item.result) {
       throw new RstParseError(`Python rST renderer batch returned no result for ${item.file}.`);
     }
-    renderedByFile.set(path.resolve(item.file), item.result);
+    renderedByFile.set(canonicalizeSourcePath(item.file), item.result);
   }
 
   return renderedByFile;
@@ -392,7 +400,7 @@ export function renderRstFilesBatch(entries: PythonRstBatchEntry[]): Map<string,
 
   const batchResults = runPythonRstRendererBatch(uncachedEntries);
   for (const entry of uncachedEntries) {
-    const result = batchResults.get(path.resolve(entry.file));
+    const result = batchResults.get(canonicalizeSourcePath(entry.file));
     if (!result) {
       throw new RstParseError(`Python rST renderer batch returned no result for ${entry.file}.`);
     }

--- a/tests/integration/series.test.ts
+++ b/tests/integration/series.test.ts
@@ -17,6 +17,7 @@ describe("Integration: Series", () => {
     expect(series).toHaveProperty("rst-legacy");
     expect(series).toHaveProperty("rst-readme");
     expect(series).toHaveProperty("rst-toctree");
+    expect(series).toHaveProperty("rst-toctree-precedence");
   });
 
   test("getSeriesData returns metadata with correct fields", () => {
@@ -125,6 +126,15 @@ describe("Integration: Series", () => {
     const posts = getSeriesPosts("rst-toctree");
     expect(posts.map(post => post.slug)).toEqual(["second-post", "first-post"]);
     expect(posts.every(post => post.sourceFormat === "rst")).toBe(true);
+  });
+
+  test("explicit rST posts metadata takes precedence over toctree order", () => {
+    const data = getSeriesData("rst-toctree-precedence");
+    expect(data).not.toBeNull();
+    expect(data!.posts).toEqual(["first-post", "second-post"]);
+
+    const posts = getSeriesPosts("rst-toctree-precedence");
+    expect(posts.map(post => post.slug)).toEqual(["first-post", "second-post"]);
   });
 
   test("getFeaturedPosts returns only posts with featured: true", () => {

--- a/tests/integration/series.test.ts
+++ b/tests/integration/series.test.ts
@@ -16,6 +16,7 @@ describe("Integration: Series", () => {
     expect(series).toHaveProperty("digital-garden");
     expect(series).toHaveProperty("rst-legacy");
     expect(series).toHaveProperty("rst-readme");
+    expect(series).toHaveProperty("rst-toctree");
   });
 
   test("getSeriesData returns metadata with correct fields", () => {
@@ -48,6 +49,15 @@ describe("Integration: Series", () => {
     expect(data!.title).toBe("Rst README Series");
     expect(data!.sourceFormat).toBe("rst");
     expect(data!.posts).toEqual(["readme-index-post"]);
+  });
+
+  test("getSeriesData derives manual order from rST toctree when posts metadata is absent", () => {
+    const data = getSeriesData("rst-toctree");
+    expect(data).not.toBeNull();
+    expect(data!.title).toBe("Rst Toctree Series");
+    expect(data!.sourceFormat).toBe("rst");
+    expect(data!.sort).toBe("manual");
+    expect(data!.posts).toEqual(["second-post", "first-post"]);
   });
 
   test("getSeriesData rejects unsafe series slugs", () => {
@@ -109,6 +119,12 @@ describe("Integration: Series", () => {
     const posts = getSeriesPosts("rst-readme");
     expect(posts.map(post => post.slug)).toEqual(["readme-index-post"]);
     expect(posts[0]?.sourceFormat).toBe("rst");
+  });
+
+  test("getSeriesPosts follows rST toctree order when posts metadata is absent", () => {
+    const posts = getSeriesPosts("rst-toctree");
+    expect(posts.map(post => post.slug)).toEqual(["second-post", "first-post"]);
+    expect(posts.every(post => post.sourceFormat === "rst")).toBe(true);
   });
 
   test("getFeaturedPosts returns only posts with featured: true", () => {


### PR DESCRIPTION
## Summary

This PR tightens the current rST/docutils path in three user-visible areas:

- restores the docutils-backed runtime rendering path so real rST posts render figures/images again
- improves light-mode code block contrast for docutils literal blocks
- adds simple toctree-based series ordering as a fallback when explicit :posts: metadata is absent

It also locks down the new ordering precedence with integration coverage and documents the author-facing behavior in the README files.

## What Changed

- route bun dev, bun run build, and bun run build:dev through a small wrapper that prefers the repo-local .venv-rst/bin/python when available
- raise the Python renderer buffer and normalize batch result keys so large batch output does not force the content layer back onto the legacy fallback path
- strengthen light-mode styling for docutils pre.literal-block code blocks
- derive rST series order from simple local .. toctree:: entries in index.rst / README.rst when :posts: metadata is absent
- keep explicit :posts: metadata as the stronger signal
- add fixture coverage for both toctree fallback ordering and :posts: precedence
- document the new ordering behavior in both README.md and README.zh.md

## Validation

- bun test src/lib/rst-renderer.test.ts src/components/RstRenderer.test.tsx
- bun test tests/integration/series.test.ts
- bun run lint

## Notes

- the runtime wrapper only prefers .venv-rst/bin/python when it exists; otherwise the existing AMYTIS_RST_PYTHON / python3 behavior remains
- toctree support in this PR is intentionally narrow: simple local entries only, used for series order fallback rather than full Sphinx-style navigation semantics


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * rST series now honor explicit :posts: ordering, falling back to toctree order then date.

* **Documentation**
  * README (EN/ZH) updated with rST series ordering and precedence rules.

* **Improvements**
  * Better styling for rendered rST code blocks.
  * Increased renderer capacity for large rST outputs.

* **Tests**
  * Added integration tests validating rST toctree ordering and :posts: precedence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->