### PR TITLE
fix: tighten rst legacy post handling

### DIFF
--- a/src/lib/markdown.ts
+++ b/src/lib/markdown.ts
@@ -1239,11 +1239,12 @@ export function getAdjacentPosts(slug: string): { prev: PostData | null; next: P
     bySlug = new Map();
     adjacentPostsCache.set(cacheKey, bySlug);
   }
-  const cached = bySlug.get(slug);
-  if (cached) return cached;
-
   const currentPost = getPostBySlug(slug);
   if (currentPost?.series) {
+    const seriesCacheKey = `${currentPost.series}/${slug}`;
+    const cachedSeries = bySlug.get(seriesCacheKey);
+    if (cachedSeries) return cachedSeries;
+
     const seriesData = getSeriesData(currentPost.series);
     if (seriesData?.type !== 'collection') {
       const seriesPosts = getSeriesPosts(currentPost.series);
@@ -1253,11 +1254,14 @@ export function getAdjacentPosts(slug: string): { prev: PostData | null; next: P
           prev: seriesIndex > 0 ? seriesPosts[seriesIndex - 1] : null,
           next: seriesIndex < seriesPosts.length - 1 ? seriesPosts[seriesIndex + 1] : null,
         };
-        bySlug.set(slug, seriesResult);
+        bySlug.set(seriesCacheKey, seriesResult);
         return seriesResult;
       }
     }
   }
+
+  const cached = bySlug.get(slug);
+  if (cached) return cached;
 
   const allPosts = getAllPosts(); // sorted desc by date (newest first)
   const index = allPosts.findIndex(p => p.slug === slug);

--- a/src/lib/markdown.ts
+++ b/src/lib/markdown.ts
@@ -1242,6 +1242,23 @@ export function getAdjacentPosts(slug: string): { prev: PostData | null; next: P
   const cached = bySlug.get(slug);
   if (cached) return cached;
 
+  const currentPost = getPostBySlug(slug);
+  if (currentPost?.series) {
+    const seriesData = getSeriesData(currentPost.series);
+    if (seriesData?.type !== 'collection') {
+      const seriesPosts = getSeriesPosts(currentPost.series);
+      const seriesIndex = seriesPosts.findIndex(post => post.slug === slug);
+      if (seriesIndex !== -1) {
+        const seriesResult = {
+          prev: seriesIndex > 0 ? seriesPosts[seriesIndex - 1] : null,
+          next: seriesIndex < seriesPosts.length - 1 ? seriesPosts[seriesIndex + 1] : null,
+        };
+        bySlug.set(slug, seriesResult);
+        return seriesResult;
+      }
+    }
+  }
+
   const allPosts = getAllPosts(); // sorted desc by date (newest first)
   const index = allPosts.findIndex(p => p.slug === slug);
   if (index === -1) {

--- a/src/lib/rst-renderer.test.ts
+++ b/src/lib/rst-renderer.test.ts
@@ -44,9 +44,12 @@ describe('rst-renderer bridge', () => {
     });
   });
 
-  test('normalizes legacy non-zero-padded dates from python output', () => {
-    const metadata = normalizePythonRstMetadata({ date: '2022-3-17' });
-    expect(metadata.date).toBe('2022-03-17');
+  test.each([
+    ['2022-3-17', '2022-03-17'],
+    ['2022-3-7', '2022-03-07'],
+  ])('normalizes legacy non-zero-padded dates from python output (%s)', (input, expected) => {
+    const metadata = normalizePythonRstMetadata({ date: input });
+    expect(metadata.date).toBe(expected);
   });
 
   test('rejects malformed supported metadata from python output', () => {

--- a/src/lib/rst-renderer.test.ts
+++ b/src/lib/rst-renderer.test.ts
@@ -105,7 +105,7 @@ describe('rst-renderer bridge', () => {
     expect(doc.metadata.authors).toEqual(['John Hu']);
   });
 
-  fixtureTest('derives excerpt and text from body content instead of docinfo', () => {
+  fixtureTest('derives text from body content without auto-generating an excerpt', () => {
     const doc = renderRstFile(
       'content/series/软件构架设计/关于队列模型.rst',
       'posts/关于队列模型'
@@ -114,7 +114,7 @@ describe('rst-renderer bridge', () => {
     expect(doc.text.startsWith('关于队列模型')).toBe(true);
     expect(doc.text.includes('Kenneth Lee 版权所有 2024')).toBe(false);
     expect(doc.text.includes('\n\n0.2\n\n')).toBe(false);
-    expect(doc.excerpt.startsWith('关于队列模型')).toBe(true);
+    expect(doc.excerpt).toBe('');
   });
 
   fixtureTest('does not render docinfo or comments at the top of post HTML', () => {
@@ -187,7 +187,7 @@ describe('rst-renderer bridge', () => {
     expect(doc.html).toContain('class="footnote-list brackets"');
     expect(doc.text).not.toContain('我这里说争论纯粹是指技术上的真理探讨');
     expect(doc.text).not.toContain('关于这一点，可以参考这里：计算进化史');
-    expect(doc.excerpt).not.toContain('我这里说争论纯粹是指技术上的真理探讨');
+    expect(doc.excerpt).toBe('');
   });
 
   fixtureTest('renders legacy :ref: roles as internal links instead of system-message blocks', () => {

--- a/src/lib/rst-renderer.test.ts
+++ b/src/lib/rst-renderer.test.ts
@@ -141,18 +141,17 @@ describe('rst-renderer bridge', () => {
     expect(doc.warnings).toEqual([]);
   });
 
-  fixtureTest('falls back cleanly for unresolved external-style :doc: targets', () => {
+  fixtureTest('resolves cross-series :doc: targets when the target content exists locally', () => {
     const doc = renderRstFile(
       'content/series/软件构架设计/无名概念的深入探讨.rst',
       'posts/无名概念的深入探讨'
     );
 
     expect(doc.html).not.toContain('system-message');
-    expect(doc.html).toContain('<span class="docutils literal">道具体是指什么</span>');
+    expect(doc.html).toContain('href="/道德经直译/道具体是指什么"');
+    expect(doc.html).toContain('href="/道德经直译/无名"');
     expect(doc.html).toContain('href="/软件构架设计/弟子规：美国军方禁止在C语言程序中使用malloc"');
-    expect(doc.warnings.length).toBe(2);
-    expect(doc.warnings[0]).toContain('../道德经直译/道具体是指什么');
-    expect(doc.warnings[1]).toContain('../道德经直译/无名');
+    expect(doc.warnings).toEqual([]);
   });
 
   fixtureTest('renders real code blocks through docutils with pygments classes', () => {

--- a/src/lib/rst-renderer.test.ts
+++ b/src/lib/rst-renderer.test.ts
@@ -3,6 +3,7 @@ import path from 'node:path';
 import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
 import { normalizePythonRstMetadata, renderRstFile, validatePythonRstResult } from './rst-renderer';
 import { RstParseError } from './rst';
+import { getPostUrl } from './urls';
 
 const localDocutilsPython = path.join(process.cwd(), '.venv-rst', 'bin', 'python');
 const hasLocalDocutils = existsSync(localDocutilsPython);
@@ -41,6 +42,11 @@ describe('rst-renderer bridge', () => {
       redirectFrom: ['/series/old-slug'],
       coverImage: './images/cover.png',
     });
+  });
+
+  test('normalizes legacy non-zero-padded dates from python output', () => {
+    const metadata = normalizePythonRstMetadata({ date: '2022-3-17' });
+    expect(metadata.date).toBe('2022-03-17');
   });
 
   test('rejects malformed supported metadata from python output', () => {
@@ -147,10 +153,14 @@ describe('rst-renderer bridge', () => {
       'posts/无名概念的深入探讨'
     );
 
+    const daoConcreteUrl = getPostUrl({ series: '道德经直译', slug: '道具体是指什么' });
+    const daoNamelessUrl = getPostUrl({ series: '道德经直译', slug: '无名' });
+    const discipleRulesUrl = getPostUrl({ series: '软件构架设计', slug: '弟子规：美国军方禁止在C语言程序中使用malloc' });
+
     expect(doc.html).not.toContain('system-message');
-    expect(doc.html).toContain('href="/道德经直译/道具体是指什么"');
-    expect(doc.html).toContain('href="/道德经直译/无名"');
-    expect(doc.html).toContain('href="/软件构架设计/弟子规：美国军方禁止在C语言程序中使用malloc"');
+    expect(doc.html).toContain(`href="${daoConcreteUrl}"`);
+    expect(doc.html).toContain(`href="${daoNamelessUrl}"`);
+    expect(doc.html).toContain(`href="${discipleRulesUrl}"`);
     expect(doc.warnings).toEqual([]);
   });
 

--- a/src/lib/rst-renderer.ts
+++ b/src/lib/rst-renderer.ts
@@ -100,16 +100,20 @@ function parseStringArray(field: string, value: unknown): string[] {
 
 function parseDate(value: unknown): string {
   const date = parseString('date', value);
-  if (!/^\d{4}-\d{2}-\d{2}$/.test(date)) {
+  const match = date.match(/^(\d{4})-(\d{1,2})-(\d{1,2})$/);
+  if (!match) {
     throw new RstParseError(`Invalid date: ${date}`);
   }
 
-  const parsed = new Date(`${date}T00:00:00Z`);
-  if (Number.isNaN(parsed.getTime()) || parsed.toISOString().slice(0, 10) !== date) {
+  const [, year, month, day] = match;
+  const normalized = `${year}-${month.padStart(2, '0')}-${day.padStart(2, '0')}`;
+
+  const parsed = new Date(`${normalized}T00:00:00Z`);
+  if (Number.isNaN(parsed.getTime()) || parsed.toISOString().slice(0, 10) !== normalized) {
     throw new RstParseError(`Invalid date: ${date}`);
   }
 
-  return date;
+  return normalized;
 }
 
 function parseSort(value: unknown): 'date-desc' | 'date-asc' | 'manual' {

--- a/src/lib/rst-renderer.ts
+++ b/src/lib/rst-renderer.ts
@@ -218,12 +218,6 @@ function calculateReadingTimeFromText(text: string): string {
   return `${Math.max(1, Math.ceil(estimatedMinutes))} min read`;
 }
 
-function generateExcerptFromText(text: string): string {
-  const plain = text.replace(/\s+/g, ' ').trim();
-  if (plain.length <= 160) return plain;
-  return `${plain.slice(0, 160).trim()}...`;
-}
-
 export function validatePythonRstResult(result: PythonRstRenderResult, filePath: string): void {
   if (!result || typeof result !== 'object') {
     throw new RstParseError(`Invalid renderer output for ${filePath}: expected object.`);
@@ -374,7 +368,7 @@ export function renderRstFile(filePath: string, imageBaseSlug: string): Rendered
     text: result.text,
     headings: result.headings,
     metadata,
-    excerpt: metadata.excerpt || generateExcerptFromText(result.text),
+    excerpt: metadata.excerpt ?? '',
     readingTime: calculateReadingTimeFromText(result.text),
     assets: result.assets ?? [],
     warnings: (result.warnings ?? []).map((warning) => String(warning)),
@@ -416,7 +410,7 @@ export function renderRstFilesBatch(entries: PythonRstBatchEntry[]): Map<string,
       text: result.text,
       headings: result.headings,
       metadata,
-      excerpt: metadata.excerpt || generateExcerptFromText(result.text),
+      excerpt: metadata.excerpt ?? '',
       readingTime: calculateReadingTimeFromText(result.text),
       assets: result.assets ?? [],
       warnings: (result.warnings ?? []).map((warning) => String(warning)),

--- a/src/lib/rst.test.ts
+++ b/src/lib/rst.test.ts
@@ -114,7 +114,7 @@ describe('rst utils', () => {
     expect(doc.body).toBe('正文。');
   });
 
-  test('strips markdown links when generating excerpts', () => {
+  test('does not auto-generate excerpts when rST metadata omits them', () => {
     const doc = parseRstDocument([
       'Title',
       '=====',
@@ -122,8 +122,19 @@ describe('rst utils', () => {
       'Paragraph with `Link <https://example.com>`_.',
     ].join('\n'));
 
-    expect(doc.excerpt).toContain('Link');
-    expect(doc.excerpt).not.toContain('[Link]');
-    expect(doc.excerpt).not.toContain('https://example.com');
+    expect(doc.excerpt).toBe('');
+  });
+
+  test('preserves explicit excerpts from rST metadata', () => {
+    const doc = parseRstDocument([
+      'Title',
+      '=====',
+      '',
+      ':excerpt: Paragraph with `Link <https://example.com>`_.',
+      '',
+      'Body.',
+    ].join('\n'));
+
+    expect(doc.excerpt).toBe('Paragraph with `Link <https://example.com>`_.');
   });
 });

--- a/src/lib/rst.test.ts
+++ b/src/lib/rst.test.ts
@@ -83,6 +83,19 @@ describe('rst utils', () => {
     ].join('\n'))).toThrow(RstParseError);
   });
 
+  test('accepts legacy non-zero-padded dates and normalizes them', () => {
+    const doc = parseRstDocument([
+      'Title',
+      '=====',
+      '',
+      ':date: 2022-3-17',
+      '',
+      'Body',
+    ].join('\n'));
+
+    expect(doc.metadata.date).toBe('2022-03-17');
+  });
+
   test('accepts leading comments and metadata before the document title', () => {
     const doc = parseRstDocument([
       '.. Kenneth Lee 版权所有 2018-2020',

--- a/src/lib/rst.ts
+++ b/src/lib/rst.ts
@@ -435,22 +435,6 @@ function calculateReadingTime(content: string): string {
   return `${minutes} min read`;
 }
 
-function generateExcerpt(content: string): string {
-  let plain = content.replace(/^#+\s+/gm, '');
-  plain = plain.replace(/```[\s\S]*?```/g, '');
-  plain = plain.replace(/!\[[^\]]*\]\([^)]+\)/g, '');
-  plain = plain.replace(/\[([^\]]+)\]\([^)]+\)/g, '$1');
-  plain = plain.replace(/(\$\*\*|__|\*|_)/g, '');
-  plain = plain.replace(/`([^`]+)`/g, '$1');
-  plain = plain.replace(/^>\s+/gm, '');
-  plain = plain.replace(/\s+/g, ' ').trim();
-
-  if (plain.length <= 160) {
-    return plain;
-  }
-  return plain.slice(0, 160).trim() + '...';
-}
-
 function getHeadings(content: string): RstHeading[] {
   const regex = /^(#{2,3})\s+(.*)$/gm;
   const headings: RstHeading[] = [];
@@ -480,7 +464,7 @@ export function parseRstDocument(source: string): ParsedRstDocument {
     markdownBody,
     metadata,
     headings: getHeadings(markdownBody),
-    excerpt: metadata.excerpt || generateExcerpt(markdownBody),
+    excerpt: metadata.excerpt ?? '',
     readingTime: calculateReadingTime(markdownBody),
   };
 }

--- a/src/lib/rst.ts
+++ b/src/lib/rst.ts
@@ -108,16 +108,20 @@ function parseCsv(value: string): string[] {
 }
 
 function parseDate(value: string): string {
-  if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) {
+  const match = value.match(/^(\d{4})-(\d{1,2})-(\d{1,2})$/);
+  if (!match) {
     throw new RstParseError(`Invalid date: ${value}`);
   }
 
-  const parsed = new Date(`${value}T00:00:00Z`);
-  if (Number.isNaN(parsed.getTime()) || parsed.toISOString().slice(0, 10) !== value) {
+  const [, year, month, day] = match;
+  const normalized = `${year}-${month.padStart(2, '0')}-${day.padStart(2, '0')}`;
+
+  const parsed = new Date(`${normalized}T00:00:00Z`);
+  if (Number.isNaN(parsed.getTime()) || parsed.toISOString().slice(0, 10) !== normalized) {
     throw new RstParseError(`Invalid date: ${value}`);
   }
 
-  return value;
+  return normalized;
 }
 
 function parseSort(value: string): 'date-desc' | 'date-asc' | 'manual' {

--- a/tests/integration/series.test.ts
+++ b/tests/integration/series.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { parseRstDocument, RstParseError } from "../../src/lib/rst";
 import {
   getAllSeries,
+  getAdjacentPosts,
   getSeriesData,
   getSeriesPosts,
   getFeaturedPosts,
@@ -126,6 +127,16 @@ describe("Integration: Series", () => {
     const posts = getSeriesPosts("rst-toctree");
     expect(posts.map(post => post.slug)).toEqual(["second-post", "first-post"]);
     expect(posts.every(post => post.sourceFormat === "rst")).toBe(true);
+  });
+
+  test("getAdjacentPosts follows rST series order instead of global post date order", () => {
+    const first = getAdjacentPosts("second-post");
+    expect(first.prev?.slug ?? null).toBeNull();
+    expect(first.next?.slug).toBe("first-post");
+
+    const second = getAdjacentPosts("first-post");
+    expect(second.prev?.slug).toBe("second-post");
+    expect(second.next?.slug ?? null).toBeNull();
   });
 
   test("explicit rST posts metadata takes precedence over toctree order", () => {

--- a/tests/integration/series.test.ts
+++ b/tests/integration/series.test.ts
@@ -130,12 +130,12 @@ describe("Integration: Series", () => {
   });
 
   test("getAdjacentPosts follows rST series order instead of global post date order", () => {
-    const first = getAdjacentPosts("second-post");
+    const first = getAdjacentPosts("getting-started");
     expect(first.prev?.slug ?? null).toBeNull();
-    expect(first.next?.slug).toBe("first-post");
+    expect(first.next?.slug).toBe("deeper-notes");
 
-    const second = getAdjacentPosts("first-post");
-    expect(second.prev?.slug).toBe("second-post");
+    const second = getAdjacentPosts("deeper-notes");
+    expect(second.prev?.slug).toBe("getting-started");
     expect(second.next?.slug ?? null).toBeNull();
   });
 


### PR DESCRIPTION
## Summary

This PR fixes a small cluster of issues surfaced by newly imported legacy rST content.

## What Changed

- accept legacy non-zero-padded rST dates like `2022-3-17` and normalize them to `YYYY-MM-DD`
- make post prev/next navigation follow the ordered series sequence for non-collection series posts instead of the global post list
- stop auto-generating excerpts for rST posts when `:excerpt:` metadata is absent

## Validation

- `bun test src/lib/rst.test.ts src/lib/rst-renderer.test.ts`
- `bun test tests/integration/series.test.ts`
- `bun run lint`

## Notes

- the date compatibility fix was applied in both the legacy rST parser path and the docutils-backed renderer path
- explicit `:excerpt:` metadata is still preserved as-is for rST posts
- this PR does not include any generated build output


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Series-aware previous/next navigation: posts in a series follow the series’ manual order for adjacent links.

* **Improvements**
  * Date parsing accepts 1–2 digit month/day and normalizes to YYYY-MM-DD.

* **Changes**
  * Missing excerpt metadata now yields an empty excerpt instead of an auto-generated snippet.

* **Tests**
  * Added tests for series navigation, date normalization, and excerpt behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->