### PR TITLE
fix: improve rst doc references and rendering parity

### DIFF
--- a/scripts/render-rst.py
+++ b/scripts/render-rst.py
@@ -263,7 +263,7 @@ def temporary_role_overrides(source_file: Path, warnings: list[str]):
     from docutils.parsers.rst import roles
 
     if not hasattr(roles, "_role_registry") or not hasattr(roles, "_roles"):
-        raise RuntimeError(
+        raise RstRenderError(
             "Incompatible docutils roles registry layout. Expected _role_registry and _roles "
             "attributes for temporary role overrides."
         )
@@ -350,8 +350,13 @@ def normalize_metadata_value(key: str, value: str) -> Any:
 
 
 def normalize_legacy_doc_role_syntax(source: str) -> str:
+    if LEGACY_DOC_ROLE_BOUNDARY in source or LEGACY_DOC_ROLE_BOUNDARY_WITH_SPACE in source:
+        raise RstRenderError(
+            f'Source already contains reserved legacy :doc: boundary marker "{LEGACY_DOC_ROLE_BOUNDARY}".'
+        )
+
     return re.sub(
-        r"(?<![\s(\[{<])(:doc:`[^`\n]+`)",
+        r"(?<![\s\\(\[{<])(:doc:`[^`\n]+`)",
         LEGACY_DOC_ROLE_BOUNDARY_WITH_SPACE + r"\1",
         source,
     )

--- a/scripts/render-rst.py
+++ b/scripts/render-rst.py
@@ -7,6 +7,7 @@ import json
 import posixpath
 import re
 import sys
+from contextlib import contextmanager
 from html.parser import HTMLParser
 from pathlib import Path
 from typing import Any
@@ -253,6 +254,33 @@ def register_passthrough_roles(warnings: list[str]) -> None:
         roles.register_canonical_role(role_name, make_passthrough_role(role_name))
     roles.register_canonical_role("ref", ref_role)
     roles.register_canonical_role("numref", numref_role)
+
+
+@contextmanager
+def temporary_role_overrides(source_file: Path, warnings: list[str]):
+    from docutils.parsers.rst import roles
+
+    tracked_names = ("doc", "dtag", "ref", "numref")
+    previous_registry = {name: roles._role_registry.get(name) for name in tracked_names}
+    previous_local = {name: roles._roles.get(name) for name in tracked_names}
+
+    register_doc_role(source_file, warnings)
+    register_passthrough_roles(warnings)
+
+    try:
+        yield
+    finally:
+        for name, role_fn in previous_registry.items():
+            if role_fn is None:
+                roles._role_registry.pop(name, None)
+            else:
+                roles._role_registry[name] = role_fn
+
+        for name, role_fn in previous_local.items():
+            if role_fn is None:
+                roles._roles.pop(name, None)
+            else:
+                roles._roles[name] = role_fn
 
 
 def parse_args() -> argparse.Namespace:
@@ -558,18 +586,17 @@ def render_single_file(source_file: Path, image_base_slug: str, strict: bool) ->
     from docutils.core import publish_doctree
 
     warnings: list[str] = []
-    register_doc_role(source_file, warnings)
-    register_passthrough_roles(warnings)
     source = source_file.read_text(encoding="utf-8")
-    document = publish_doctree(
-        source=source,
-        settings_overrides={
-            "report_level": 2,
-            "halt_level": 5,
-            "file_insertion_enabled": False,
-            "raw_enabled": False,
-        },
-    )
+    with temporary_role_overrides(source_file, warnings):
+        document = publish_doctree(
+            source=source,
+            settings_overrides={
+                "report_level": 2,
+                "halt_level": 5,
+                "file_insertion_enabled": False,
+                "raw_enabled": False,
+            },
+        )
     remove_system_messages(document)
     output = build_output(document, source_file, image_base_slug, warnings)
 

--- a/scripts/render-rst.py
+++ b/scripts/render-rst.py
@@ -27,7 +27,8 @@ SCALAR_FIELDS = {
     "sort",
     "type",
 }
-LEGACY_DOC_ROLE_BOUNDARY = "\u00a0"
+LEGACY_DOC_ROLE_BOUNDARY = "__AMYTIS_RST_DOC_ROLE_BOUNDARY__"
+LEGACY_DOC_ROLE_BOUNDARY_WITH_SPACE = f"{LEGACY_DOC_ROLE_BOUNDARY} "
 
 
 class RstRenderError(Exception):
@@ -261,6 +262,12 @@ def register_passthrough_roles(warnings: list[str]) -> None:
 def temporary_role_overrides(source_file: Path, warnings: list[str]):
     from docutils.parsers.rst import roles
 
+    if not hasattr(roles, "_role_registry") or not hasattr(roles, "_roles"):
+        raise RuntimeError(
+            "Incompatible docutils roles registry layout. Expected _role_registry and _roles "
+            "attributes for temporary role overrides."
+        )
+
     tracked_names = ("doc", "dtag", "ref", "numref")
     previous_registry = {name: roles._role_registry.get(name) for name in tracked_names}
     previous_local = {name: roles._roles.get(name) for name in tracked_names}
@@ -345,7 +352,7 @@ def normalize_metadata_value(key: str, value: str) -> Any:
 def normalize_legacy_doc_role_syntax(source: str) -> str:
     return re.sub(
         r"(?<![\s(\[{<])(:doc:`[^`\n]+`)",
-        LEGACY_DOC_ROLE_BOUNDARY + r"\1",
+        LEGACY_DOC_ROLE_BOUNDARY_WITH_SPACE + r"\1",
         source,
     )
 
@@ -516,7 +523,7 @@ def extract_body_text(document: Any) -> str:
         if text:
             body_parts.append(text)
 
-    return "\n\n".join(body_parts).replace(LEGACY_DOC_ROLE_BOUNDARY, "").strip()
+    return "\n\n".join(body_parts).replace(LEGACY_DOC_ROLE_BOUNDARY_WITH_SPACE, "").replace(LEGACY_DOC_ROLE_BOUNDARY, "").strip()
 
 
 def remove_system_messages(document: Any) -> None:
@@ -567,7 +574,7 @@ def extract_html_body_from_doctree(document: Any) -> str:
     if not html_fragment:
         raise RstRenderError("Docutils HTML output did not contain a <main> or <body> fragment.")
 
-    return html_fragment.replace(LEGACY_DOC_ROLE_BOUNDARY, "")
+    return html_fragment.replace(LEGACY_DOC_ROLE_BOUNDARY_WITH_SPACE, "").replace(LEGACY_DOC_ROLE_BOUNDARY, "")
 
 
 def build_output(document: Any, source_file: Path, image_base_slug: str, warnings: list[str]) -> dict[str, Any]:

--- a/scripts/render-rst.py
+++ b/scripts/render-rst.py
@@ -27,6 +27,7 @@ SCALAR_FIELDS = {
     "sort",
     "type",
 }
+LEGACY_DOC_ROLE_BOUNDARY = "\u00a0"
 
 
 class RstRenderError(Exception):
@@ -341,6 +342,14 @@ def normalize_metadata_value(key: str, value: str) -> Any:
     return stripped
 
 
+def normalize_legacy_doc_role_syntax(source: str) -> str:
+    return re.sub(
+        r"(?<![\s(\[{<])(:doc:`[^`\n]+`)",
+        LEGACY_DOC_ROLE_BOUNDARY + r"\1",
+        source,
+    )
+
+
 def extract_metadata(document: Any) -> dict[str, Any]:
     from docutils import nodes
 
@@ -507,7 +516,7 @@ def extract_body_text(document: Any) -> str:
         if text:
             body_parts.append(text)
 
-    return "\n\n".join(body_parts).strip()
+    return "\n\n".join(body_parts).replace(LEGACY_DOC_ROLE_BOUNDARY, "").strip()
 
 
 def remove_system_messages(document: Any) -> None:
@@ -558,7 +567,7 @@ def extract_html_body_from_doctree(document: Any) -> str:
     if not html_fragment:
         raise RstRenderError("Docutils HTML output did not contain a <main> or <body> fragment.")
 
-    return html_fragment
+    return html_fragment.replace(LEGACY_DOC_ROLE_BOUNDARY, "")
 
 
 def build_output(document: Any, source_file: Path, image_base_slug: str, warnings: list[str]) -> dict[str, Any]:
@@ -586,7 +595,7 @@ def render_single_file(source_file: Path, image_base_slug: str, strict: bool) ->
     from docutils.core import publish_doctree
 
     warnings: list[str] = []
-    source = source_file.read_text(encoding="utf-8")
+    source = normalize_legacy_doc_role_syntax(source_file.read_text(encoding="utf-8"))
     with temporary_role_overrides(source_file, warnings):
         document = publish_doctree(
             source=source,

--- a/scripts/render-rst.py
+++ b/scripts/render-rst.py
@@ -114,8 +114,9 @@ def slug_from_doc_path(doc_path: Path) -> str:
 
 def resolve_doc_target_path(source_file: Path, target: str) -> Path | None:
     candidate_base = (source_file.parent / target).resolve()
+    candidate_rst = candidate_base if candidate_base.suffix == ".rst" else candidate_base.parent / f"{candidate_base.name}.rst"
     candidate_paths = [
-        candidate_base.with_suffix(".rst"),
+        candidate_rst,
         candidate_base / "index.rst",
         candidate_base / "README.rst",
     ]

--- a/src/app/[slug]/page/[page]/page.tsx
+++ b/src/app/[slug]/page/[page]/page.tsx
@@ -57,6 +57,21 @@ export async function generateStaticParams() {
     }
   }
 
+  // Work around Next dev static-param checks for percent-encoded Unicode slugs
+  // under `output: "export"` — dev server may receive encoded forms of the
+  // prefix segment for paginated listings.
+  if (process.env.NODE_ENV !== 'production') {
+    const existing = new Set(params.map(p => `${p.slug}/${p.page}`));
+    for (const p of [...params]) {
+      const encodedSlug = encodeURIComponent(p.slug);
+      const key = `${encodedSlug}/${p.page}`;
+      if (!existing.has(key)) {
+        existing.add(key);
+        params.push({ slug: encodedSlug, page: p.page });
+      }
+    }
+  }
+
   // Placeholder keeps Next.js happy with output: export when no custom paths configured.
   // dynamicParams = false ensures any unrecognised slug/page combo returns 404.
   return params.length > 0 ? params : [{ slug: '_', page: '2' }];

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -518,9 +518,21 @@ body {
   color: var(--accent);
 }
 
-.rst-rendered .numref {
+.rst-rendered a[href]:not([role="doc-noteref"]) {
   color: var(--accent);
-  font-weight: 600;
+  text-decoration: none;
+  transition: color 160ms ease, text-decoration-color 160ms ease;
+}
+
+.rst-rendered a[href]:not([role="doc-noteref"]):hover,
+.rst-rendered a[href]:not([role="doc-noteref"]):focus-visible {
+  color: var(--accent);
+  text-decoration: underline;
+}
+
+.rst-rendered .numref {
+  color: inherit;
+  font-weight: inherit;
 }
 
 .rst-rendered math {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -535,6 +535,19 @@ body {
   font-weight: inherit;
 }
 
+.rst-rendered .rst-table-wrapper {
+  overflow-x: auto;
+  margin: 2rem 0;
+  border: 1px solid color-mix(in srgb, var(--muted) 20%, transparent);
+  border-radius: 0.5rem;
+}
+
+.rst-rendered .rst-table-wrapper > table {
+  min-width: 100%;
+  margin: 0;
+  font-size: 0.875rem;
+}
+
 .rst-rendered math {
   display: inline-block;
   max-width: 100%;

--- a/src/components/RstRenderer.test.tsx
+++ b/src/components/RstRenderer.test.tsx
@@ -53,6 +53,20 @@ describe('RstRenderer', () => {
     expect(html).toContain('<mi>x</mi>');
   });
 
+  test('wraps rendered rst tables with the same scroll container pattern as markdown', () => {
+    const html = renderToStaticMarkup(
+      <RstRenderer
+        content="Fallback body"
+        html={'<table><thead><tr><th>A</th></tr></thead><tbody><tr><td>B</td></tr></tbody></table>'}
+      />
+    );
+
+    expect(html).toContain('class="rst-table-wrapper"');
+    expect(html).toContain('<table>');
+    expect(html).toContain('<th>A</th>');
+    expect(html).toContain('<td>B</td>');
+  });
+
   test('renders converted headings, links, and code blocks through the markdown renderer', () => {
     const html = renderToStaticMarkup(
       <RstRenderer

--- a/src/components/RstRenderer.tsx
+++ b/src/components/RstRenderer.tsx
@@ -93,13 +93,18 @@ function sanitizeRenderedHtml(html: string): string {
 
 export default function RstRenderer({ content, html, latex = false, slug, slugRegistry }: RstRendererProps) {
   if (html) {
+    const sanitizedHtml = sanitizeRenderedHtml(html).replace(
+      /<table\b([^>]*)>/g,
+      '<div class="rst-table-wrapper"><table$1>'
+    ).replace(/<\/table>/g, '</table></div>');
+
     return (
       <>
         {latex && <KatexStyles />}
         <div className="bg-background">
           <div
             className={`${proseClasses} rst-rendered`}
-            dangerouslySetInnerHTML={{ __html: sanitizeRenderedHtml(html) }}
+            dangerouslySetInnerHTML={{ __html: sanitizedHtml }}
           />
         </div>
       </>

--- a/src/lib/rst-renderer.test.ts
+++ b/src/lib/rst-renderer.test.ts
@@ -167,6 +167,24 @@ describe('rst-renderer bridge', () => {
     expect(doc.warnings).toEqual([]);
   });
 
+  fixtureTest('does not leak :doc: role resolution across sequential renders in one process', () => {
+    renderRstFile(
+      'content/series/花朵的温室/读史的方法.rst',
+      'posts/读史的方法'
+    );
+
+    const doc = renderRstFile(
+      'content/series/软件构架设计/什么是架构设计2023.rst',
+      'posts/什么是架构设计2023'
+    );
+
+    expect(doc.html).toContain('href="/软件构架设计/什么是软件架构"');
+    expect(doc.html).not.toContain('<span class="docutils literal">什么是软件架构</span>');
+    expect(doc.warnings).toEqual([
+      'Unsupported interpreted text role ":dtag:" rendered as plain inline text.',
+    ]);
+  });
+
   fixtureTest('resolves same-series :doc: targets whose rst filenames contain dots', () => {
     const doc = renderRstFile(
       'content/series/道德经直译/德信.rst',

--- a/src/lib/rst-renderer.test.ts
+++ b/src/lib/rst-renderer.test.ts
@@ -167,6 +167,31 @@ describe('rst-renderer bridge', () => {
     expect(doc.warnings).toEqual([]);
   });
 
+  fixtureTest('resolves same-series :doc: targets whose rst filenames contain dots', () => {
+    const doc = renderRstFile(
+      'content/series/道德经直译/德信.rst',
+      'posts/德信'
+    );
+
+    const targetUrl = getPostUrl({ series: '道德经直译', slug: '02.不尚贤' });
+
+    expect(doc.html).not.toContain('system-message');
+    expect(doc.html).toContain(`href="${targetUrl}"`);
+    expect(doc.warnings).toEqual([]);
+  });
+
+  fixtureTest('resolves version-like :doc: targets whose rst filenames contain dots', () => {
+    const doc = renderRstFile(
+      'content/series/Linux主线内核跟踪/6.5.rst',
+      'posts/6.5'
+    );
+
+    const targetUrl = getPostUrl({ series: 'Linux主线内核跟踪', slug: '6.2' });
+
+    expect(doc.html).toContain(`href="${targetUrl}"`);
+    expect(doc.warnings).toEqual([]);
+  });
+
   fixtureTest('renders real code blocks through docutils with pygments classes', () => {
     const doc = renderRstFile(
       'content/series/软件构架设计/大型软件架构设计.rst',

--- a/src/lib/rst-renderer.test.ts
+++ b/src/lib/rst-renderer.test.ts
@@ -191,8 +191,9 @@ describe('rst-renderer bridge', () => {
       'content/series/软件构架设计/什么是架构设计2023.rst',
       'posts/什么是架构设计2023'
     );
+    const targetUrl = getPostUrl({ series: '软件构架设计', slug: '什么是软件架构' });
 
-    expect(doc.html).toContain('href="/软件构架设计/什么是软件架构"');
+    expect(doc.html).toContain(`href="${targetUrl}"`);
     expect(doc.html).not.toContain('<span class="docutils literal">什么是软件架构</span>');
     expect(doc.warnings).toEqual([
       'Unsupported interpreted text role ":dtag:" rendered as plain inline text.',

--- a/src/lib/rst-renderer.test.ts
+++ b/src/lib/rst-renderer.test.ts
@@ -167,6 +167,20 @@ describe('rst-renderer bridge', () => {
     expect(doc.warnings).toEqual([]);
   });
 
+  fixtureTest('resolves cross-series :doc: links when legacy content omits a boundary before the role', () => {
+    const doc = renderRstFile(
+      'content/series/花朵的温室/读史的方法.rst',
+      'posts/读史的方法'
+    );
+
+    const targetUrl = getPostUrl({ series: '道德经直译', slug: '温故而知新' });
+
+    expect(doc.html).toContain(`href="${targetUrl}"`);
+    expect(doc.html).not.toContain(':doc:<cite>');
+    expect(doc.html).not.toContain('<span class="docutils literal">温故而知新</span>');
+    expect(doc.warnings).toEqual([]);
+  });
+
   fixtureTest('does not leak :doc: role resolution across sequential renders in one process', () => {
     renderRstFile(
       'content/series/花朵的温室/读史的方法.rst',


### PR DESCRIPTION
## Summary

This PR improves the HTML-first rST path in two areas:

- fixes additional real-world `:doc:` reference cases from imported legacy rST content
- brings rST-rendered post presentation closer to Markdown posts for common elements

## What Changed

- fix dotted-filename `:doc:` targets like `6.2` and `02.不尚贤`
- prevent docutils role overrides from leaking across sequential renders in long-lived dev processes
- support legacy inline `...:doc:`target`` syntax when older content omits a boundary before the role
- keep the Unicode paginated series dev-route workaround aligned with the post route
- align rST body-link styling with Markdown links
- wrap docutils-rendered tables in the same scrollable container pattern used by Markdown tables

## Validation

- `bun test src/lib/rst-renderer.test.ts`
- `bun test src/components/RstRenderer.test.tsx`
- `bun run lint`

## Notes

- coverage includes real imported fixture pages for same-series and cross-series `:doc:` references
- the new regression also covers the long-lived dev-process failure mode where one rST page could affect the next page's role resolution


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Responsive table wrappers for rendered RST tables and improved link styling with smoother hover/focus behavior.
* **Bug Fixes**
  * More reliable RST :doc: link resolution that avoids literal fallbacks and reduces spurious warnings.
  * Prefer explicit .rst targets when resolving document links for more accurate hrefs.
* **Tests**
  * Added tests covering table-wrapping and multiple RST link-resolution scenarios to prevent regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->