### PR TITLE
fix: improve rst build diagnostics and python compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v1
         with:
-          bun-version: latest
+          bun-version: 1.3.11
 
       - name: Install dependencies
         run: bun install --frozen-lockfile

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,7 +19,7 @@ jobs:
       
       - uses: oven-sh/setup-bun@v1
         with:
-          bun-version: latest
+          bun-version: 1.3.11
       
       - run: bun install --frozen-lockfile
       
@@ -43,7 +43,7 @@ jobs:
       
       - uses: oven-sh/setup-bun@v1
         with:
-          bun-version: latest
+          bun-version: 1.3.11
       
       - run: bun install --frozen-lockfile
       

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "homepage": "https://github.com/hutusi/amytis#readme",
   "private": false,
-  "packageManager": "bun@1.3.4",
+  "packageManager": "bun@1.3.11",
   "scripts": {
     "dev": "bun scripts/run-with-rst-python.ts next dev",
     "build": "bun scripts/copy-assets.ts && bun run build:graph && bun scripts/run-with-rst-python.ts next build && next-image-export-optimizer && pagefind --site out",

--- a/scripts/render-rst.py
+++ b/scripts/render-rst.py
@@ -306,15 +306,21 @@ def parse_args() -> argparse.Namespace:
         help="Read a JSON array of batch render entries from stdin",
     )
     parser.add_argument(
+        "--batch-file",
+        help="Read a JSON array of batch render entries from a file",
+    )
+    parser.add_argument(
         "--strict",
         action="store_true",
         help="Fail on missing local assets instead of reporting them in the output",
     )
     args = parser.parse_args()
 
-    if args.batch_stdin:
+    if args.batch_stdin or args.batch_file:
+        if args.batch_stdin and args.batch_file:
+            parser.error("--batch-stdin and --batch-file cannot be combined")
         if args.file or args.image_base_slug:
-            parser.error("--batch-stdin cannot be combined with --file or --image-base-slug")
+            parser.error("--batch-stdin/--batch-file cannot be combined with --file or --image-base-slug")
         return args
 
     if not args.file or not args.image_base_slug:
@@ -634,8 +640,7 @@ def render_single_file(source_file: Path, image_base_slug: str, strict: bool) ->
     return output
 
 
-def render_batch(strict: bool) -> list[dict[str, Any]]:
-    raw_input = sys.stdin.read()
+def render_batch(raw_input: str, strict: bool) -> list[dict[str, Any]]:
     try:
         entries = json.loads(raw_input)
     except json.JSONDecodeError as exc:
@@ -682,8 +687,12 @@ def main() -> int:
         return 1
 
     try:
-        if args.batch_stdin:
-            print(json.dumps(render_batch(args.strict), ensure_ascii=False))
+        if args.batch_stdin or args.batch_file:
+            if args.batch_file:
+                raw_batch_input = Path(args.batch_file).read_text(encoding="utf-8")
+            else:
+                raw_batch_input = sys.stdin.read()
+            print(json.dumps(render_batch(raw_batch_input, args.strict), ensure_ascii=False))
             return 0
 
         source_file = resolve_source_file(args.file)

--- a/scripts/render-rst.py
+++ b/scripts/render-rst.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 
+from __future__ import annotations
+
 import argparse
 import copy
 import html

--- a/src/lib/markdown.test.ts
+++ b/src/lib/markdown.test.ts
@@ -1,5 +1,36 @@
-import { describe, expect, test } from "bun:test";
-import { generateExcerpt, calculateReadingTime, getHeadings, getAuthorSlug } from "./markdown";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, test } from "bun:test";
+import { RstParseError } from "./rst";
+import {
+  generateExcerpt,
+  calculateReadingTime,
+  getHeadings,
+  getAuthorSlug,
+  getPythonRstRendererAvailabilityForTests,
+  parseRstFileForTests,
+  resetPythonRstRendererAvailabilityForTests,
+} from "./markdown";
+
+const previousEnablePythonRst = process.env.AMYTIS_ENABLE_PYTHON_RST;
+const previousRstPython = process.env.AMYTIS_RST_PYTHON;
+
+afterEach(() => {
+  if (previousEnablePythonRst === undefined) {
+    delete process.env.AMYTIS_ENABLE_PYTHON_RST;
+  } else {
+    process.env.AMYTIS_ENABLE_PYTHON_RST = previousEnablePythonRst;
+  }
+
+  if (previousRstPython === undefined) {
+    delete process.env.AMYTIS_RST_PYTHON;
+  } else {
+    process.env.AMYTIS_RST_PYTHON = previousRstPython;
+  }
+
+  resetPythonRstRendererAvailabilityForTests();
+});
 
 describe("markdown utils", () => {
   describe("generateExcerpt", () => {
@@ -122,6 +153,55 @@ describe("markdown utils", () => {
       expect(getAuthorSlug("Amytis Team")).toBe("amytis-team");
       expect(getAuthorSlug("[author]")).toBe("author");
       expect(getAuthorSlug(" John Hu ")).toBe("john-hu");
+    });
+  });
+
+  describe("rST parsing fallbacks", () => {
+    test("includes the source file path in rst parse errors", () => {
+      process.env.AMYTIS_ENABLE_PYTHON_RST = "0";
+
+      const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "amytis-rst-"));
+      const filePath = path.join(tempDir, "broken.rst");
+      fs.writeFileSync(
+        filePath,
+        [
+          ":Date: 2021-16-15",
+          "",
+          "Broken Title",
+          "************",
+          "",
+          "Body",
+          "",
+        ].join("\n"),
+        "utf8",
+      );
+
+      try {
+        expect(() => parseRstFileForTests(filePath, "broken")).toThrow(
+          new RstParseError(`Invalid date: 2021-16-15 (${filePath})`)
+        );
+      } finally {
+        fs.rmSync(tempDir, { recursive: true, force: true });
+      }
+    });
+
+    test("falls back to the legacy rst parser when python runtime is unavailable", () => {
+      process.env.AMYTIS_ENABLE_PYTHON_RST = "1";
+      process.env.AMYTIS_RST_PYTHON = "python-does-not-exist";
+      resetPythonRstRendererAvailabilityForTests();
+
+      const post = parseRstFileForTests(
+        path.join(process.cwd(), "content/series/rst-legacy/getting-started.rst"),
+        "getting-started",
+        undefined,
+        "rst-legacy",
+      );
+
+      expect(post.title).toBe("Getting Started With rST");
+      expect(post.renderedHtml).toBeUndefined();
+      expect(post.content).toContain("Overview\n--------");
+      expect(post.content).toContain(".. code-block:: ts");
+      expect(getPythonRstRendererAvailabilityForTests()).toBe(false);
     });
   });
 });

--- a/src/lib/markdown.ts
+++ b/src/lib/markdown.ts
@@ -5,7 +5,7 @@ import { siteConfig } from '../../site.config';
 import GithubSlugger from 'github-slugger';
 import { z } from 'zod';
 import { getPostUrl } from './urls';
-import { parseRstDocument } from './rst';
+import { parseRstDocument, RstParseError } from './rst';
 import { renderRstFile, renderRstFilesBatch, type RenderedRstDocument } from './rst-renderer';
 
 const contentDirectory = path.join(process.cwd(), 'content', 'posts');
@@ -657,126 +657,132 @@ function parseRstFile(
   seriesName?: string,
   preRendered?: RenderedRstDocument,
 ): PostData {
-  const imageBaseSlug = getRstImageBaseSlug(fullPath, slug);
-  const fileContents = fs.readFileSync(fullPath, 'utf8');
-
-  let parsedTitle: string;
-  let parsedBody: string;
-  let parsedText: string | undefined;
-  let parsedHeadings: Heading[];
-  let parsedExcerpt: string;
-  let parsedReadingTime: string;
-  let parsedHtml: string | undefined;
-  let data: ReturnType<typeof parseRstDocument>['metadata'];
   try {
-    if (preRendered) {
-      const rendered = preRendered;
-      parsedTitle = rendered.title;
-      parsedBody = rendered.text;
-      parsedText = rendered.text;
-      parsedHeadings = rendered.headings;
-      parsedExcerpt = rendered.excerpt;
-      parsedReadingTime = rendered.readingTime;
-      parsedHtml = rendered.html;
-      data = rendered.metadata;
-    } else if (shouldUsePythonRstRenderer() && pythonRstRendererAvailable !== false) {
-      const rendered = renderRstFile(fullPath, imageBaseSlug);
-      pythonRstRendererAvailable = true;
-      parsedTitle = rendered.title;
-      parsedBody = rendered.text;
-      parsedText = rendered.text;
-      parsedHeadings = rendered.headings;
-      parsedExcerpt = rendered.excerpt;
-      parsedReadingTime = rendered.readingTime;
-      parsedHtml = rendered.html;
-      data = rendered.metadata;
-    } else {
-      throw new Error('__RST_FALLBACK__');
-    }
-  } catch (error) {
-    if (!isPythonRuntimeUnavailable(error)) {
-      throw error;
-    }
-    if (pythonRstRendererAvailable !== false) {
-      pythonRstRendererAvailable = false;
-    }
-    const parsed = parseRstDocument(fileContents);
-    parsedTitle = parsed.title;
-    parsedBody = parsed.body;
-    parsedHeadings = parsed.headings;
-    parsedExcerpt = parsed.excerpt;
-    parsedReadingTime = parsed.readingTime;
-    data = parsed.metadata;
-  }
+    const imageBaseSlug = getRstImageBaseSlug(fullPath, slug);
+    const fileContents = fs.readFileSync(fullPath, 'utf8');
 
-  const effectiveSeriesSlug = data.series || seriesName;
-  let authors: string[] = [];
-  if (data.authors && data.authors.length > 0) {
-    authors = data.authors;
-  } else if (data.author) {
-    authors = [data.author];
-  } else {
-    if (effectiveSeriesSlug) {
-      const seriesAuthors = getSeriesAuthors(effectiveSeriesSlug);
-      if (seriesAuthors) authors = seriesAuthors;
+    let parsedTitle: string;
+    let parsedBody: string;
+    let parsedText: string | undefined;
+    let parsedHeadings: Heading[];
+    let parsedExcerpt: string;
+    let parsedReadingTime: string;
+    let parsedHtml: string | undefined;
+    let data: ReturnType<typeof parseRstDocument>['metadata'];
+    try {
+      if (preRendered) {
+        const rendered = preRendered;
+        parsedTitle = rendered.title;
+        parsedBody = rendered.text;
+        parsedText = rendered.text;
+        parsedHeadings = rendered.headings;
+        parsedExcerpt = rendered.excerpt;
+        parsedReadingTime = rendered.readingTime;
+        parsedHtml = rendered.html;
+        data = rendered.metadata;
+      } else if (shouldUsePythonRstRenderer() && pythonRstRendererAvailable !== false) {
+        const rendered = renderRstFile(fullPath, imageBaseSlug);
+        pythonRstRendererAvailable = true;
+        parsedTitle = rendered.title;
+        parsedBody = rendered.text;
+        parsedText = rendered.text;
+        parsedHeadings = rendered.headings;
+        parsedExcerpt = rendered.excerpt;
+        parsedReadingTime = rendered.readingTime;
+        parsedHtml = rendered.html;
+        data = rendered.metadata;
+      } else {
+        throw new Error('__RST_FALLBACK__');
+      }
+    } catch (error) {
+      if (!isPythonRuntimeUnavailable(error)) {
+        throw error;
+      }
+      if (pythonRstRendererAvailable !== false) {
+        pythonRstRendererAvailable = false;
+      }
+      const parsed = parseRstDocument(fileContents);
+      parsedTitle = parsed.title;
+      parsedBody = parsed.body;
+      parsedHeadings = parsed.headings;
+      parsedExcerpt = parsed.excerpt;
+      parsedReadingTime = parsed.readingTime;
+      data = parsed.metadata;
     }
-    if (authors.length === 0) {
-      const defaultAuthors = siteConfig.posts?.authors?.default;
-      if (defaultAuthors && defaultAuthors.length > 0) {
-        authors = defaultAuthors;
+
+    const effectiveSeriesSlug = data.series || seriesName;
+    let authors: string[] = [];
+    if (data.authors && data.authors.length > 0) {
+      authors = data.authors;
+    } else if (data.author) {
+      authors = [data.author];
+    } else {
+      if (effectiveSeriesSlug) {
+        const seriesAuthors = getSeriesAuthors(effectiveSeriesSlug);
+        if (seriesAuthors) authors = seriesAuthors;
+      }
+      if (authors.length === 0) {
+        const defaultAuthors = siteConfig.posts?.authors?.default;
+        if (defaultAuthors && defaultAuthors.length > 0) {
+          authors = defaultAuthors;
+        }
       }
     }
+
+    let date = data.date;
+    if (!date && dateFromFileName) date = dateFromFileName;
+    if (!date) date = new Date().toISOString().split('T')[0];
+
+    let coverImage = data.coverImage;
+    if (coverImage && !coverImage.startsWith('http') && !coverImage.startsWith('/') && !coverImage.startsWith('text:')) {
+      const cleanPath = coverImage.replace(/^\.\//, '');
+      coverImage = `/${imageBaseSlug}/${cleanPath}`;
+    }
+    const toctreePosts = isSeriesIndexRst(fullPath, slug, seriesName)
+      ? extractRstToctreePosts(fileContents)
+      : [];
+    const seriesPosts = data.posts && data.posts.length > 0
+      ? data.posts
+      : ((data.sort === undefined || data.sort === 'manual') && toctreePosts.length > 0 ? toctreePosts : undefined);
+    const sort = data.sort ?? (seriesPosts ? 'manual' : 'date-desc');
+
+    return {
+      slug,
+      title: parsedTitle,
+      subtitle: data.subtitle,
+      date,
+      excerpt: data.excerpt || parsedExcerpt,
+      category: data.category ?? 'Uncategorized',
+      tags: data.tags ?? [],
+      authors,
+      layout: data.layout ?? 'post',
+      series: effectiveSeriesSlug,
+      seriesTitle: effectiveSeriesSlug ? getSeriesTitle(effectiveSeriesSlug) : undefined,
+      coverImage,
+      sort,
+      posts: seriesPosts,
+      type: data.type,
+      featured: data.featured ?? false,
+      pinned: data.pinned ?? false,
+      draft: data.draft ?? false,
+      latex: data.latex ?? false,
+      toc: data.toc ?? true,
+      commentable: data.commentable,
+      redirectFrom: data.redirectFrom ?? [],
+      readingTime: parsedReadingTime,
+      content: parsedBody,
+      renderedHtml: parsedHtml,
+      plainText: parsedText,
+      headings: parsedHeadings,
+      imageBaseSlug,
+      sourceFormat: 'rst',
+    };
+  } catch (error) {
+    if (error instanceof RstParseError) {
+      throw new RstParseError(`${error.message} (${fullPath})`);
+    }
+    throw error;
   }
-
-  let date = data.date;
-  if (!date && dateFromFileName) date = dateFromFileName;
-  if (!date) date = new Date().toISOString().split('T')[0];
-
-  let coverImage = data.coverImage;
-  if (coverImage && !coverImage.startsWith('http') && !coverImage.startsWith('/') && !coverImage.startsWith('text:')) {
-    const cleanPath = coverImage.replace(/^\.\//, '');
-    coverImage = `/${imageBaseSlug}/${cleanPath}`;
-  }
-
-  const toctreePosts = isSeriesIndexRst(fullPath, slug, seriesName)
-    ? extractRstToctreePosts(fileContents)
-    : [];
-  const seriesPosts = data.posts && data.posts.length > 0
-    ? data.posts
-    : ((data.sort === undefined || data.sort === 'manual') && toctreePosts.length > 0 ? toctreePosts : undefined);
-  const sort = data.sort ?? (seriesPosts ? 'manual' : 'date-desc');
-
-  return {
-    slug,
-    title: parsedTitle,
-    subtitle: data.subtitle,
-    date,
-    excerpt: data.excerpt || parsedExcerpt,
-    category: data.category ?? 'Uncategorized',
-    tags: data.tags ?? [],
-    authors,
-    layout: data.layout ?? 'post',
-    series: effectiveSeriesSlug,
-    seriesTitle: effectiveSeriesSlug ? getSeriesTitle(effectiveSeriesSlug) : undefined,
-    coverImage,
-    sort,
-    posts: seriesPosts,
-    type: data.type,
-    featured: data.featured ?? false,
-    pinned: data.pinned ?? false,
-    draft: data.draft ?? false,
-    latex: data.latex ?? false,
-    toc: data.toc ?? true,
-    commentable: data.commentable,
-    redirectFrom: data.redirectFrom ?? [],
-    readingTime: parsedReadingTime,
-    content: parsedBody,
-    renderedHtml: parsedHtml,
-    plainText: parsedText,
-    headings: parsedHeadings,
-    imageBaseSlug,
-    sourceFormat: 'rst',
-  };
 }
 
 export function getAllPosts(): PostData[] {

--- a/src/lib/markdown.ts
+++ b/src/lib/markdown.ts
@@ -785,6 +785,24 @@ function parseRstFile(
   }
 }
 
+export function parseRstFileForTests(
+  fullPath: string,
+  slug: string,
+  dateFromFileName?: string,
+  seriesName?: string,
+  preRendered?: RenderedRstDocument,
+): PostData {
+  return parseRstFile(fullPath, slug, dateFromFileName, seriesName, preRendered);
+}
+
+export function resetPythonRstRendererAvailabilityForTests(value: boolean | null = null): void {
+  pythonRstRendererAvailable = value;
+}
+
+export function getPythonRstRendererAvailabilityForTests(): boolean | null {
+  return pythonRstRendererAvailable;
+}
+
 export function getAllPosts(): PostData[] {
   const cacheKey = getCacheEnvKey();
   const cached = postsCache.get(cacheKey);

--- a/src/lib/rst-renderer.test.ts
+++ b/src/lib/rst-renderer.test.ts
@@ -1,7 +1,13 @@
 import { existsSync } from 'node:fs';
 import path from 'node:path';
 import { afterAll, beforeAll, describe, expect, test } from 'bun:test';
-import { normalizePythonRstMetadata, renderRstFile, validatePythonRstResult } from './rst-renderer';
+import {
+  getPythonCommandSpecForRstRenderer,
+  normalizePythonRstMetadata,
+  resetPythonCommandSpecForTests,
+  renderRstFile,
+  validatePythonRstResult,
+} from './rst-renderer';
 import { RstParseError } from './rst';
 import { getPostUrl } from './urls';
 
@@ -11,6 +17,7 @@ const fixtureTest = hasLocalDocutils ? test : test.skip;
 const previousPython = process.env.AMYTIS_RST_PYTHON;
 
 beforeAll(() => {
+  resetPythonCommandSpecForTests();
   if (hasLocalDocutils && previousPython === undefined) {
     process.env.AMYTIS_RST_PYTHON = localDocutilsPython;
   }
@@ -22,6 +29,7 @@ afterAll(() => {
   } else {
     process.env.AMYTIS_RST_PYTHON = previousPython;
   }
+  resetPythonCommandSpecForTests();
 });
 
 describe('rst-renderer bridge', () => {
@@ -76,6 +84,27 @@ describe('rst-renderer bridge', () => {
       headings: [],
       metadata: {},
     }, 'broken.rst')).toThrow(RstParseError);
+  });
+
+  test('prefers the configured python runtime when provided', () => {
+    const previousPython = process.env.AMYTIS_RST_PYTHON;
+    process.env.AMYTIS_RST_PYTHON = '/tmp/custom-python';
+    resetPythonCommandSpecForTests();
+
+    try {
+      expect(getPythonCommandSpecForRstRenderer()).toEqual({
+        executable: '/tmp/custom-python',
+        args: [],
+        cacheKey: '/tmp/custom-python',
+      });
+    } finally {
+      if (previousPython === undefined) {
+        delete process.env.AMYTIS_RST_PYTHON;
+      } else {
+        process.env.AMYTIS_RST_PYTHON = previousPython;
+      }
+      resetPythonCommandSpecForTests();
+    }
   });
 
   fixtureTest('renders a real legacy rST page with rewritten figure asset URLs', () => {

--- a/src/lib/rst-renderer.ts
+++ b/src/lib/rst-renderer.ts
@@ -76,17 +76,6 @@ function getRenderCacheKey(filePath: string, imageBaseSlug: string): string {
   return `${getPythonCommandSpecForRstRenderer().cacheKey}::${filePath}::${imageBaseSlug}::${stats.mtimeMs}::${stats.size}`;
 }
 
-function getBundledPythonPath(): string | null {
-  const bundledPython = path.join(
-    process.cwd(),
-    '.venv-rst',
-    process.platform === 'win32' ? 'Scripts' : 'bin',
-    process.platform === 'win32' ? 'python.exe' : 'python',
-  );
-
-  return fs.existsSync(bundledPython) ? bundledPython : null;
-}
-
 export function getPythonCommandSpecForRstRenderer(): PythonCommandSpec {
   if (resolvedPythonCommandSpec) {
     return resolvedPythonCommandSpec;
@@ -97,16 +86,6 @@ export function getPythonCommandSpecForRstRenderer(): PythonCommandSpec {
       executable: process.env.AMYTIS_RST_PYTHON,
       args: [],
       cacheKey: process.env.AMYTIS_RST_PYTHON,
-    };
-    return resolvedPythonCommandSpec;
-  }
-
-  const bundledPython = getBundledPythonPath();
-  if (bundledPython) {
-    resolvedPythonCommandSpec = {
-      executable: bundledPython,
-      args: [],
-      cacheKey: bundledPython,
     };
     return resolvedPythonCommandSpec;
   }

--- a/src/lib/rst-renderer.ts
+++ b/src/lib/rst-renderer.ts
@@ -1,6 +1,7 @@
 import { spawnSync } from 'node:child_process';
 import fs from 'node:fs';
 import path from 'node:path';
+import os from 'node:os';
 import { RstMetadata, RstParseError } from './rst';
 
 export interface PythonRstHeading {
@@ -349,16 +350,46 @@ export function runPythonRstRendererBatch(entries: PythonRstBatchEntry[]): Map<s
 
   const scriptPath = path.join(process.cwd(), 'scripts', 'render-rst.py');
   const pythonCommand = getPythonCommandSpecForRstRenderer();
-  const result = spawnSync(pythonCommand.executable, [
-    ...pythonCommand.args,
-    scriptPath,
-    '--batch-stdin',
-    '--strict',
-  ], {
-    encoding: 'utf8',
-    input: JSON.stringify(entries),
-    maxBuffer: PYTHON_RENDERER_MAX_BUFFER,
-  });
+  const shouldUseBatchFile = process.platform === 'win32' && pythonCommand.executable === 'py';
+  let batchFilePath: string | null = null;
+
+  const result = (() => {
+    if (shouldUseBatchFile) {
+      const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'amytis-rst-batch-'));
+      batchFilePath = path.join(tempDir, 'batch.json');
+      fs.writeFileSync(batchFilePath, JSON.stringify(entries), 'utf8');
+
+      return spawnSync(pythonCommand.executable, [
+        ...pythonCommand.args,
+        scriptPath,
+        '--batch-file',
+        batchFilePath,
+        '--strict',
+      ], {
+        encoding: 'utf8',
+        maxBuffer: PYTHON_RENDERER_MAX_BUFFER,
+      });
+    }
+
+    return spawnSync(pythonCommand.executable, [
+      ...pythonCommand.args,
+      scriptPath,
+      '--batch-stdin',
+      '--strict',
+    ], {
+      encoding: 'utf8',
+      input: JSON.stringify(entries),
+      maxBuffer: PYTHON_RENDERER_MAX_BUFFER,
+    });
+  })();
+
+  if (batchFilePath) {
+    try {
+      fs.rmSync(path.dirname(batchFilePath), { recursive: true, force: true });
+    } catch {
+      // Best-effort cleanup for Windows batch temp files.
+    }
+  }
 
   if (result.error) {
     throw new RstParseError(`Failed to run Python rST renderer batch: ${result.error.message}`);

--- a/src/lib/rst-renderer.ts
+++ b/src/lib/rst-renderer.ts
@@ -64,6 +64,12 @@ export function resetPythonCommandSpecForTests(): void {
   resolvedPythonCommandSpec = null;
 }
 
+function ensureSpawnOutputString(output: string | NodeJS.ArrayBufferView | null | undefined): string {
+  if (typeof output === 'string') return output;
+  if (!output) return '';
+  return Buffer.from(output.buffer, output.byteOffset, output.byteLength).toString('utf8');
+}
+
 function canonicalizeSourcePath(filePath: string): string {
   try {
     return fs.realpathSync(filePath);
@@ -110,6 +116,12 @@ export function getPythonCommandSpecForRstRenderer(): PythonCommandSpec {
       return resolvedPythonCommandSpec;
     }
   }
+
+  console.warn(
+    `[rst-renderer] No Python candidate responded to --version; using fallback ${candidates.map((candidate) =>
+      [candidate.executable, ...candidate.args].join(' ')
+    ).join(', ')}`
+  );
 
   resolvedPythonCommandSpec = process.platform === 'win32'
     ? { executable: 'py', args: ['-3'], cacheKey: 'py::-3' }
@@ -330,14 +342,17 @@ export function runPythonRstRenderer(filePath: string, imageBaseSlug: string): P
     throw new RstParseError(`Failed to run Python rST renderer for ${filePath}: ${result.error.message}`);
   }
 
+  const stderr = ensureSpawnOutputString(result.stderr);
+  const stdout = ensureSpawnOutputString(result.stdout);
+
   if (result.status !== 0) {
     throw new RstParseError(
-      result.stderr.trim() || `Python rST renderer exited with status ${result.status} for ${filePath}.`
+      stderr.trim() || `Python rST renderer exited with status ${result.status} for ${filePath}.`
     );
   }
 
   try {
-    return JSON.parse(result.stdout) as PythonRstRenderResult;
+    return JSON.parse(stdout) as PythonRstRenderResult;
   } catch (error) {
     throw new RstParseError(
       `Invalid JSON from Python rST renderer for ${filePath}: ${error instanceof Error ? error.message : String(error)}`
@@ -353,13 +368,14 @@ export function runPythonRstRendererBatch(entries: PythonRstBatchEntry[]): Map<s
   const shouldUseBatchFile = process.platform === 'win32' && pythonCommand.executable === 'py';
   let batchFilePath: string | null = null;
 
-  const result = (() => {
+  let result: ReturnType<typeof spawnSync>;
+  try {
     if (shouldUseBatchFile) {
       const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'amytis-rst-batch-'));
       batchFilePath = path.join(tempDir, 'batch.json');
       fs.writeFileSync(batchFilePath, JSON.stringify(entries), 'utf8');
 
-      return spawnSync(pythonCommand.executable, [
+      result = spawnSync(pythonCommand.executable, [
         ...pythonCommand.args,
         scriptPath,
         '--batch-file',
@@ -369,25 +385,25 @@ export function runPythonRstRendererBatch(entries: PythonRstBatchEntry[]): Map<s
         encoding: 'utf8',
         maxBuffer: PYTHON_RENDERER_MAX_BUFFER,
       });
+    } else {
+      result = spawnSync(pythonCommand.executable, [
+        ...pythonCommand.args,
+        scriptPath,
+        '--batch-stdin',
+        '--strict',
+      ], {
+        encoding: 'utf8',
+        input: JSON.stringify(entries),
+        maxBuffer: PYTHON_RENDERER_MAX_BUFFER,
+      });
     }
-
-    return spawnSync(pythonCommand.executable, [
-      ...pythonCommand.args,
-      scriptPath,
-      '--batch-stdin',
-      '--strict',
-    ], {
-      encoding: 'utf8',
-      input: JSON.stringify(entries),
-      maxBuffer: PYTHON_RENDERER_MAX_BUFFER,
-    });
-  })();
-
-  if (batchFilePath) {
-    try {
-      fs.rmSync(path.dirname(batchFilePath), { recursive: true, force: true });
-    } catch {
-      // Best-effort cleanup for Windows batch temp files.
+  } finally {
+    if (batchFilePath) {
+      try {
+        fs.rmSync(path.dirname(batchFilePath), { recursive: true, force: true });
+      } catch {
+        // Best-effort cleanup for Windows batch temp files.
+      }
     }
   }
 
@@ -395,15 +411,18 @@ export function runPythonRstRendererBatch(entries: PythonRstBatchEntry[]): Map<s
     throw new RstParseError(`Failed to run Python rST renderer batch: ${result.error.message}`);
   }
 
+  const stderr = ensureSpawnOutputString(result.stderr);
+  const stdout = ensureSpawnOutputString(result.stdout);
+
   if (result.status !== 0) {
     throw new RstParseError(
-      result.stderr.trim() || `Python rST renderer batch exited with status ${result.status}.`
+      stderr.trim() || `Python rST renderer batch exited with status ${result.status}.`
     );
   }
 
   let parsed: PythonRstBatchResponseItem[];
   try {
-    parsed = JSON.parse(result.stdout) as PythonRstBatchResponseItem[];
+    parsed = JSON.parse(stdout) as PythonRstBatchResponseItem[];
   } catch (error) {
     throw new RstParseError(
       `Invalid JSON from Python rST renderer batch: ${error instanceof Error ? error.message : String(error)}`

--- a/src/lib/rst-renderer.ts
+++ b/src/lib/rst-renderer.ts
@@ -49,8 +49,19 @@ interface PythonRstBatchResponseItem {
   error?: string;
 }
 
+interface PythonCommandSpec {
+  executable: string;
+  args: string[];
+  cacheKey: string;
+}
+
 const rstRenderCache = new Map<string, RenderedRstDocument>();
 const PYTHON_RENDERER_MAX_BUFFER = 1024 * 1024 * 128;
+let resolvedPythonCommandSpec: PythonCommandSpec | null = null;
+
+export function resetPythonCommandSpecForTests(): void {
+  resolvedPythonCommandSpec = null;
+}
 
 function canonicalizeSourcePath(filePath: string): string {
   try {
@@ -62,11 +73,68 @@ function canonicalizeSourcePath(filePath: string): string {
 
 function getRenderCacheKey(filePath: string, imageBaseSlug: string): string {
   const stats = fs.statSync(filePath);
-  return `${getPythonExecutableForRstRenderer()}::${filePath}::${imageBaseSlug}::${stats.mtimeMs}::${stats.size}`;
+  return `${getPythonCommandSpecForRstRenderer().cacheKey}::${filePath}::${imageBaseSlug}::${stats.mtimeMs}::${stats.size}`;
 }
 
-function getPythonExecutableForRstRenderer(): string {
-  return process.env.AMYTIS_RST_PYTHON || 'python3';
+function getBundledPythonPath(): string | null {
+  const bundledPython = path.join(
+    process.cwd(),
+    '.venv-rst',
+    process.platform === 'win32' ? 'Scripts' : 'bin',
+    process.platform === 'win32' ? 'python.exe' : 'python',
+  );
+
+  return fs.existsSync(bundledPython) ? bundledPython : null;
+}
+
+export function getPythonCommandSpecForRstRenderer(): PythonCommandSpec {
+  if (resolvedPythonCommandSpec) {
+    return resolvedPythonCommandSpec;
+  }
+
+  if (process.env.AMYTIS_RST_PYTHON) {
+    resolvedPythonCommandSpec = {
+      executable: process.env.AMYTIS_RST_PYTHON,
+      args: [],
+      cacheKey: process.env.AMYTIS_RST_PYTHON,
+    };
+    return resolvedPythonCommandSpec;
+  }
+
+  const bundledPython = getBundledPythonPath();
+  if (bundledPython) {
+    resolvedPythonCommandSpec = {
+      executable: bundledPython,
+      args: [],
+      cacheKey: bundledPython,
+    };
+    return resolvedPythonCommandSpec;
+  }
+
+  const candidates: PythonCommandSpec[] = process.platform === 'win32'
+    ? [
+      { executable: 'py', args: ['-3'], cacheKey: 'py::-3' },
+      { executable: 'python', args: [], cacheKey: 'python' },
+    ]
+    : [
+      { executable: 'python3', args: [], cacheKey: 'python3' },
+      { executable: 'python', args: [], cacheKey: 'python' },
+    ];
+
+  for (const candidate of candidates) {
+    const probe = spawnSync(candidate.executable, [...candidate.args, '--version'], {
+      encoding: 'utf8',
+    });
+    if (!probe.error && probe.status === 0) {
+      resolvedPythonCommandSpec = candidate;
+      return resolvedPythonCommandSpec;
+    }
+  }
+
+  resolvedPythonCommandSpec = process.platform === 'win32'
+    ? { executable: 'py', args: ['-3'], cacheKey: 'py::-3' }
+    : { executable: 'python3', args: [], cacheKey: 'python3' };
+  return resolvedPythonCommandSpec;
 }
 
 function parseBoolean(field: string, value: unknown): boolean {
@@ -264,8 +332,9 @@ export function validatePythonRstResult(result: PythonRstRenderResult, filePath:
 
 export function runPythonRstRenderer(filePath: string, imageBaseSlug: string): PythonRstRenderResult {
   const scriptPath = path.join(process.cwd(), 'scripts', 'render-rst.py');
-  const pythonExecutable = getPythonExecutableForRstRenderer();
-  const result = spawnSync(pythonExecutable, [
+  const pythonCommand = getPythonCommandSpecForRstRenderer();
+  const result = spawnSync(pythonCommand.executable, [
+    ...pythonCommand.args,
     scriptPath,
     '--file',
     filePath,
@@ -300,8 +369,9 @@ export function runPythonRstRendererBatch(entries: PythonRstBatchEntry[]): Map<s
   if (entries.length === 0) return new Map();
 
   const scriptPath = path.join(process.cwd(), 'scripts', 'render-rst.py');
-  const pythonExecutable = getPythonExecutableForRstRenderer();
-  const result = spawnSync(pythonExecutable, [
+  const pythonCommand = getPythonCommandSpecForRstRenderer();
+  const result = spawnSync(pythonCommand.executable, [
+    ...pythonCommand.args,
     scriptPath,
     '--batch-stdin',
     '--strict',


### PR DESCRIPTION
## Summary

This PR fixes two cross-machine rST build issues:

- include the source `.rst` file path in parse errors so bad imported metadata is actionable during builds
- support older Python runtimes when loading the docutils-backed rST renderer

## What Changed

- [src/lib/markdown.ts](/Users/hutusi/workspace/ai/naive/amytis-codex/src/lib/markdown.ts)
  wraps `RstParseError` failures during rST post loading with the full source file path
- [scripts/render-rst.py](/Users/hutusi/workspace/ai/naive/amytis-codex/scripts/render-rst.py)
  adds `from __future__ import annotations` so modern type annotations do not crash on older Python versions used on some Windows/Linux machines

## Why

On other machines, imported legacy rST content can fail builds in ways that are hard to diagnose:

- invalid metadata such as impossible dates previously only reported the bad value
- Python 3.9 can crash importing `render-rst.py` because of evaluated `str | None` annotations

These fixes make the build failures either actionable or disappear entirely.

## Validation

- `python3 -m py_compile scripts/render-rst.py`
- `bun test src/lib/rst.test.ts src/lib/rst-renderer.test.ts tests/integration/series.test.ts`
- `bun test src/lib/rst-renderer.test.ts`
- `bun run lint`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Pinned Bun runtime/tooling to v1.3.11 across project and CI.

* **New Features**
  * Batch rendering accepts a JSON batch file via a new CLI option (in addition to stdin); improved validation for conflicting flags.
  * Better cross-platform Python runtime detection and selection for RST rendering.

* **Bug Fixes**
  * RST parse errors now include source file path for clearer diagnostics.
  * Improved fallback when the Python-based renderer is unavailable.

* **Tests**
  * Added tests covering RST error paths, Python-runtime selection, fallback behavior, and batch input handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->