### PR TITLE
fix: stabilize legacy rst builds

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -15,8 +15,8 @@ const nextConfig: NextConfig = {
   output: "export",
   images: {
     loader: "custom",
-    imageSizes: [16, 32, 64, 128, 256],
-    deviceSizes: [640, 828, 1200, 1920],
+    imageSizes: [64, 128, 256],
+    deviceSizes: [640, 1200, 1920],
   },
   transpilePackages: ["next-image-export-optimizer"],
   env: {

--- a/next.config.ts
+++ b/next.config.ts
@@ -15,8 +15,8 @@ const nextConfig: NextConfig = {
   output: "export",
   images: {
     loader: "custom",
-    imageSizes: [16, 32, 48, 64, 96, 128, 256, 384],
-    deviceSizes: [640, 750, 828, 1080, 1200, 1920, 2048, 3840],
+    imageSizes: [16, 32, 64, 128, 256],
+    deviceSizes: [640, 828, 1200, 1920],
   },
   transpilePackages: ["next-image-export-optimizer"],
   env: {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "build:search:cli": "pagefind --site out",
     "build:search:cli:dev": "pagefind --site out --output-path public/pagefind",
     "validate": "bun run lint && bun run test && bun run build:dev",
-    "clean": "rm -rf .next out public/posts public/books public/flows",
+    "clean": "rm -rf .next out public/posts public/books public/flows public/images/nextImageExportOptimizer",
     "new": "bun scripts/new-post.ts",
     "new-weekly": "bun scripts/new-post.ts --series ai-nexus-weekly --md --folder --prefix weekly",
     "new-series": "bun scripts/new-series.ts",

--- a/scripts/copy-assets.ts
+++ b/scripts/copy-assets.ts
@@ -26,34 +26,11 @@ function markGeneratedDestination(destPath: string) {
 }
 
 function shouldPreserveOptimizerDir(optimizerPath: string): boolean {
-  return generatedAssetDestinations.has(path.resolve(path.dirname(optimizerPath)));
-}
-
-function resetGeneratedTreePreservingOptimizerCache(rootDir: string) {
-  if (!fs.existsSync(rootDir)) return;
-
-  const entries = fs.readdirSync(rootDir, { withFileTypes: true });
-  for (const entry of entries) {
-    const entryPath = path.join(rootDir, entry.name);
-
-    if (entry.isDirectory()) {
-      if (entry.name === optimizerDirName) {
-        if (!shouldPreserveOptimizerDir(entryPath)) {
-          fs.rmSync(entryPath, { recursive: true, force: true });
-        }
-        continue;
-      }
-
-      resetGeneratedTreePreservingOptimizerCache(entryPath);
-
-      if (fs.existsSync(entryPath) && fs.readdirSync(entryPath).length === 0) {
-        fs.rmdirSync(entryPath);
-      }
-      continue;
-    }
-
-    fs.rmSync(entryPath, { force: true });
-  }
+  const optimizerParentPath = path.resolve(path.dirname(optimizerPath));
+  return [...generatedAssetDestinations].some((generatedDestination) =>
+    optimizerParentPath === generatedDestination ||
+    optimizerParentPath.startsWith(`${generatedDestination}${path.sep}`)
+  );
 }
 
 function pruneOrphanedOptimizerDirs(rootDir: string) {
@@ -83,43 +60,62 @@ function resetGeneratedAssetDirs() {
   fs.mkdirSync(destDir, { recursive: true });
   fs.mkdirSync(booksDestDir, { recursive: true });
   fs.mkdirSync(flowsDestDir, { recursive: true });
-  resetGeneratedTreePreservingOptimizerCache(destDir);
-  resetGeneratedTreePreservingOptimizerCache(booksDestDir);
-  resetGeneratedTreePreservingOptimizerCache(flowsDestDir);
 }
 
-function copyRecursive(src: string, dest: string) {
+function shouldSkipSourceFile(name: string): boolean {
+  return name.endsWith('.md') || name.endsWith('.mdx') || name.endsWith('.rst');
+}
+
+function syncRecursive(src: string, dest: string) {
   if (!fs.existsSync(src)) return;
-  
+
   if (!fs.existsSync(dest)) {
     fs.mkdirSync(dest, { recursive: true });
   }
 
-  const entries = fs.readdirSync(src, { withFileTypes: true });
+  const srcEntries = fs.readdirSync(src, { withFileTypes: true });
+  const srcNames = new Set(srcEntries.map((entry) => entry.name));
 
-  for (const entry of entries) {
+  for (const entry of srcEntries) {
     const srcPath = path.join(src, entry.name);
     const destPath = path.join(dest, entry.name);
 
     if (entry.isDirectory()) {
-      copyRecursive(srcPath, destPath);
+      syncRecursive(srcPath, destPath);
     } else {
-      // Copy all files except markdown source
-      if (!entry.name.endsWith('.md') && !entry.name.endsWith('.mdx') && !entry.name.endsWith('.rst')) {
-        let shouldCopy = true;
-        if (fs.existsSync(destPath)) {
-          const srcStat = fs.statSync(srcPath);
-          const destStat = fs.statSync(destPath);
-          if (srcStat.mtimeMs <= destStat.mtimeMs) {
-            shouldCopy = false;
-          }
-        }
+      if (shouldSkipSourceFile(entry.name)) {
+        continue;
+      }
 
-        if (shouldCopy) {
-          copyFileOrThrow(srcPath, destPath, 'recursive asset');
-          // console.log(`Copied: ${entry.name} -> ${destPath}`);
+      let shouldCopy = true;
+      if (fs.existsSync(destPath)) {
+        const srcStat = fs.statSync(srcPath);
+        const destStat = fs.statSync(destPath);
+        if (srcStat.mtimeMs <= destStat.mtimeMs && srcStat.size === destStat.size) {
+          shouldCopy = false;
         }
       }
+
+      if (shouldCopy) {
+        copyFileOrThrow(srcPath, destPath, 'recursive asset');
+      }
+    }
+  }
+
+  const destEntries = fs.readdirSync(dest, { withFileTypes: true });
+  for (const entry of destEntries) {
+    if (entry.name === optimizerDirName) continue;
+
+    const destPath = path.join(dest, entry.name);
+    const srcPath = path.join(src, entry.name);
+
+    if (!srcNames.has(entry.name)) {
+      fs.rmSync(destPath, { recursive: true, force: true });
+      continue;
+    }
+
+    if (entry.isDirectory() && !fs.existsSync(srcPath)) {
+      fs.rmSync(destPath, { recursive: true, force: true });
     }
   }
 }
@@ -180,8 +176,13 @@ function extractReferencedAssetPaths(filePath: string): string[] {
   return [...references];
 }
 
-function copyReferencedAssets(sourceFile: string, rootDir: string, destPostDir: string) {
+function syncReferencedAssets(sourceFile: string, rootDir: string, destPostDir: string) {
   const references = extractReferencedAssetPaths(sourceFile);
+  const desiredRelativePaths = new Set<string>();
+
+  if (!fs.existsSync(destPostDir)) {
+    fs.mkdirSync(destPostDir, { recursive: true });
+  }
 
   references.forEach((reference) => {
     const absolutePath = path.resolve(path.dirname(sourceFile), reference);
@@ -201,11 +202,60 @@ function copyReferencedAssets(sourceFile: string, rootDir: string, destPostDir: 
     }
 
     const destPath = path.join(destPostDir, relativeToRoot);
+    desiredRelativePaths.add(relativeToRoot.replaceAll(path.sep, '/'));
     if (!fs.existsSync(path.dirname(destPath))) {
       fs.mkdirSync(path.dirname(destPath), { recursive: true });
     }
-    copyFileOrThrow(absolutePath, destPath, `referenced asset from ${sourceFile}`);
+
+    let shouldCopy = true;
+    if (fs.existsSync(destPath)) {
+      const srcStat = fs.statSync(absolutePath);
+      const destStat = fs.statSync(destPath);
+      if (srcStat.mtimeMs <= destStat.mtimeMs && srcStat.size === destStat.size) {
+        shouldCopy = false;
+      }
+    }
+
+    if (shouldCopy) {
+      copyFileOrThrow(absolutePath, destPath, `referenced asset from ${sourceFile}`);
+    }
   });
+
+  function pruneDestDir(currentDir: string, relativeDir = '') {
+    if (!fs.existsSync(currentDir)) return;
+
+    const entries = fs.readdirSync(currentDir, { withFileTypes: true });
+    for (const entry of entries) {
+      if (entry.name === optimizerDirName) continue;
+
+      const relativePath = relativeDir ? path.join(relativeDir, entry.name) : entry.name;
+      const normalizedRelativePath = relativePath.replaceAll(path.sep, '/');
+      const fullPath = path.join(currentDir, entry.name);
+
+      if (entry.isDirectory()) {
+        const hasDesiredDescendant = [...desiredRelativePaths].some((desiredPath) =>
+          desiredPath === normalizedRelativePath || desiredPath.startsWith(`${normalizedRelativePath}/`)
+        );
+
+        if (!hasDesiredDescendant) {
+          fs.rmSync(fullPath, { recursive: true, force: true });
+          continue;
+        }
+
+        pruneDestDir(fullPath, relativePath);
+        if (fs.existsSync(fullPath) && fs.readdirSync(fullPath).length === 0) {
+          fs.rmdirSync(fullPath);
+        }
+        continue;
+      }
+
+      if (!desiredRelativePaths.has(normalizedRelativePath)) {
+        fs.rmSync(fullPath, { force: true });
+      }
+    }
+  }
+
+  pruneDestDir(destPostDir);
 }
 
 function processPosts() {
@@ -220,7 +270,7 @@ function processPosts() {
 
         console.log(`Processing Post: ${entry.name} -> ${targetName}`);
         markGeneratedDestination(destPostDir);
-        copyRecursive(srcPostDir, destPostDir);
+        syncRecursive(srcPostDir, destPostDir);
       } else if (entry.isFile() && (entry.name.endsWith('.md') || entry.name.endsWith('.mdx') || entry.name.endsWith('.rst'))) {
         const targetName = getSlugFromFilename(entry.name);
         const sourceFile = path.join(srcDir, entry.name);
@@ -231,7 +281,7 @@ function processPosts() {
         if (!fs.existsSync(destPostDir)) {
           fs.mkdirSync(destPostDir, { recursive: true });
         }
-        copyReferencedAssets(sourceFile, srcDir, destPostDir);
+        syncReferencedAssets(sourceFile, srcDir, destPostDir);
       }
     });
   }
@@ -270,7 +320,7 @@ function processSeries() {
             fs.mkdirSync(destPostDir, { recursive: true });
           }
 
-          copyReferencedAssets(sourceFile, seriesPath, destPostDir);
+          syncReferencedAssets(sourceFile, seriesPath, destPostDir);
 
         } else if (item.isDirectory() && isPostFolder(path.join(seriesPath, item.name))) {
           // Folder-based post: copy only its own assets
@@ -288,8 +338,8 @@ function processSeries() {
             const destPath = path.join(destPostDir, sub.name);
 
             if (sub.isDirectory()) {
-              copyRecursive(srcPath, destPath);
-            } else if (!sub.name.endsWith('.md') && !sub.name.endsWith('.mdx') && !sub.name.endsWith('.rst')) {
+              syncRecursive(srcPath, destPath);
+            } else if (!shouldSkipSourceFile(sub.name)) {
               if (!fs.existsSync(destPostDir)) {
                 fs.mkdirSync(destPostDir, { recursive: true });
               }
@@ -314,7 +364,7 @@ function processBooks() {
 
       console.log(`Processing Book: ${entry.name}`);
       markGeneratedDestination(destBookDir);
-      copyRecursive(srcBookDir, destBookDir);
+      syncRecursive(srcBookDir, destBookDir);
     }
   });
 }
@@ -345,7 +395,7 @@ function processFlows() {
 
         console.log(`Processing Flow: ${yearEntry.name}/${monthEntry.name}/${rawName}`);
         markGeneratedDestination(destFlowDir);
-        copyRecursive(srcFlowDir, destFlowDir);
+        syncRecursive(srcFlowDir, destFlowDir);
       }
     }
   }

--- a/scripts/copy-assets.ts
+++ b/scripts/copy-assets.ts
@@ -56,11 +56,36 @@ function resetGeneratedTreePreservingOptimizerCache(rootDir: string) {
   }
 }
 
+function pruneOrphanedOptimizerDirs(rootDir: string) {
+  if (!fs.existsSync(rootDir)) return;
+
+  const entries = fs.readdirSync(rootDir, { withFileTypes: true });
+  for (const entry of entries) {
+    const entryPath = path.join(rootDir, entry.name);
+
+    if (!entry.isDirectory()) {
+      continue;
+    }
+
+    if (entry.name === optimizerDirName) {
+      if (!shouldPreserveOptimizerDir(entryPath)) {
+        fs.rmSync(entryPath, { recursive: true, force: true });
+      }
+      continue;
+    }
+
+    pruneOrphanedOptimizerDirs(entryPath);
+  }
+}
+
 function resetGeneratedAssetDirs() {
   generatedAssetDestinations.clear();
   fs.mkdirSync(destDir, { recursive: true });
   fs.mkdirSync(booksDestDir, { recursive: true });
   fs.mkdirSync(flowsDestDir, { recursive: true });
+  resetGeneratedTreePreservingOptimizerCache(destDir);
+  resetGeneratedTreePreservingOptimizerCache(booksDestDir);
+  resetGeneratedTreePreservingOptimizerCache(flowsDestDir);
 }
 
 function copyRecursive(src: string, dest: string) {
@@ -332,7 +357,7 @@ processPosts();
 processSeries();
 processBooks();
 processFlows();
-resetGeneratedTreePreservingOptimizerCache(destDir);
-resetGeneratedTreePreservingOptimizerCache(booksDestDir);
-resetGeneratedTreePreservingOptimizerCache(flowsDestDir);
+pruneOrphanedOptimizerDirs(destDir);
+pruneOrphanedOptimizerDirs(booksDestDir);
+pruneOrphanedOptimizerDirs(flowsDestDir);
 console.log('Assets copied successfully.');

--- a/scripts/copy-assets.ts
+++ b/scripts/copy-assets.ts
@@ -12,6 +12,15 @@ const flowsDestDir = path.join(process.cwd(), 'public', 'flows');
 const optimizerDirName = 'nextImageExportOptimizer';
 const generatedAssetDestinations = new Set<string>();
 
+function copyFileOrThrow(srcPath: string, destPath: string, context: string) {
+  try {
+    fs.copyFileSync(srcPath, destPath);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`[copy-assets] Failed to copy ${context}: ${srcPath} -> ${destPath}: ${message}`);
+  }
+}
+
 function markGeneratedDestination(destPath: string) {
   generatedAssetDestinations.add(path.resolve(destPath));
 }
@@ -82,7 +91,7 @@ function copyRecursive(src: string, dest: string) {
         }
 
         if (shouldCopy) {
-          fs.copyFileSync(srcPath, destPath);
+          copyFileOrThrow(srcPath, destPath, 'recursive asset');
           // console.log(`Copied: ${entry.name} -> ${destPath}`);
         }
       }
@@ -170,7 +179,7 @@ function copyReferencedAssets(sourceFile: string, rootDir: string, destPostDir: 
     if (!fs.existsSync(path.dirname(destPath))) {
       fs.mkdirSync(path.dirname(destPath), { recursive: true });
     }
-    fs.copyFileSync(absolutePath, destPath);
+    copyFileOrThrow(absolutePath, destPath, `referenced asset from ${sourceFile}`);
   });
 }
 
@@ -259,7 +268,7 @@ function processSeries() {
               if (!fs.existsSync(destPostDir)) {
                 fs.mkdirSync(destPostDir, { recursive: true });
               }
-              fs.copyFileSync(srcPath, destPath);
+              copyFileOrThrow(srcPath, destPath, `series post asset from ${itemSrcPath}`);
             }
           });
         }

--- a/scripts/copy-assets.ts
+++ b/scripts/copy-assets.ts
@@ -66,6 +66,16 @@ function shouldSkipSourceFile(name: string): boolean {
   return name.endsWith('.md') || name.endsWith('.mdx') || name.endsWith('.rst');
 }
 
+function shouldCopyBasedOnMtimeAndSize(srcPath: string, destPath: string): boolean {
+  if (!fs.existsSync(destPath)) {
+    return true;
+  }
+
+  const srcStat = fs.statSync(srcPath);
+  const destStat = fs.statSync(destPath);
+  return srcStat.mtimeMs > destStat.mtimeMs || srcStat.size !== destStat.size;
+}
+
 function syncRecursive(src: string, dest: string) {
   if (!fs.existsSync(src)) return;
 
@@ -87,16 +97,7 @@ function syncRecursive(src: string, dest: string) {
         continue;
       }
 
-      let shouldCopy = true;
-      if (fs.existsSync(destPath)) {
-        const srcStat = fs.statSync(srcPath);
-        const destStat = fs.statSync(destPath);
-        if (srcStat.mtimeMs <= destStat.mtimeMs && srcStat.size === destStat.size) {
-          shouldCopy = false;
-        }
-      }
-
-      if (shouldCopy) {
+      if (shouldCopyBasedOnMtimeAndSize(srcPath, destPath)) {
         copyFileOrThrow(srcPath, destPath, 'recursive asset');
       }
     }
@@ -107,14 +108,8 @@ function syncRecursive(src: string, dest: string) {
     if (entry.name === optimizerDirName) continue;
 
     const destPath = path.join(dest, entry.name);
-    const srcPath = path.join(src, entry.name);
 
     if (!srcNames.has(entry.name)) {
-      fs.rmSync(destPath, { recursive: true, force: true });
-      continue;
-    }
-
-    if (entry.isDirectory() && !fs.existsSync(srcPath)) {
       fs.rmSync(destPath, { recursive: true, force: true });
     }
   }
@@ -207,16 +202,7 @@ function syncReferencedAssets(sourceFile: string, rootDir: string, destPostDir: 
       fs.mkdirSync(path.dirname(destPath), { recursive: true });
     }
 
-    let shouldCopy = true;
-    if (fs.existsSync(destPath)) {
-      const srcStat = fs.statSync(absolutePath);
-      const destStat = fs.statSync(destPath);
-      if (srcStat.mtimeMs <= destStat.mtimeMs && srcStat.size === destStat.size) {
-        shouldCopy = false;
-      }
-    }
-
-    if (shouldCopy) {
+    if (shouldCopyBasedOnMtimeAndSize(absolutePath, destPath)) {
       copyFileOrThrow(absolutePath, destPath, `referenced asset from ${sourceFile}`);
     }
   });
@@ -343,7 +329,9 @@ function processSeries() {
               if (!fs.existsSync(destPostDir)) {
                 fs.mkdirSync(destPostDir, { recursive: true });
               }
-              copyFileOrThrow(srcPath, destPath, `series post asset from ${itemSrcPath}`);
+              if (shouldCopyBasedOnMtimeAndSize(srcPath, destPath)) {
+                copyFileOrThrow(srcPath, destPath, `series post asset from ${itemSrcPath}`);
+              }
             }
           });
         }

--- a/src/app/series/page.tsx
+++ b/src/app/series/page.tsx
@@ -1,4 +1,4 @@
-import { getAllSeries, getSeriesData, resolveSeriesAuthors } from '@/lib/markdown';
+import { getAllSeries, getSeriesData, getSeriesLatestPostDate, resolveSeriesAuthors } from '@/lib/markdown';
 import Link from 'next/link';
 import { siteConfig } from '../../../site.config';
 import { Metadata } from 'next';
@@ -20,8 +20,8 @@ export default function SeriesIndexPage() {
 
   // Sort by most recent post date (active series first)
   const seriesSlugs = Object.keys(allSeries).sort((a, b) => {
-    const latestA = allSeries[a][0]?.date || '';
-    const latestB = allSeries[b][0]?.date || '';
+    const latestA = getSeriesLatestPostDate(a);
+    const latestB = getSeriesLatestPostDate(b);
     return latestB.localeCompare(latestA);
   });
 

--- a/src/components/AuthorCard.tsx
+++ b/src/components/AuthorCard.tsx
@@ -3,6 +3,7 @@ import ExportedImage from 'next-image-export-optimizer';
 import { getAuthorSlug } from '@/lib/markdown';
 import { siteConfig } from '../../site.config';
 import { t } from '@/lib/i18n';
+import { shouldBypassImageOptimization } from '@/lib/image-utils';
 
 const isDev = process.env.NODE_ENV === 'development';
 const isExternal = (src: string) => src.startsWith('http') || src.startsWith('//');
@@ -31,7 +32,8 @@ export default function AuthorCard({ authors }: { authors: string[] }) {
                   width={56}
                   height={56}
                   className="w-14 h-14 rounded-full object-cover flex-shrink-0 ring-2 ring-muted/20"
-                  unoptimized={isDev || isExternal(profile.avatar)}
+                  unoptimized={isDev || isExternal(profile.avatar) || shouldBypassImageOptimization(profile.avatar)}
+                  placeholder={shouldBypassImageOptimization(profile.avatar) ? 'empty' : 'blur'}
                 />
               ) : (
                 <div className="w-14 h-14 rounded-full bg-accent/10 flex items-center justify-center flex-shrink-0 text-accent font-serif font-bold text-2xl select-none">
@@ -68,7 +70,8 @@ export default function AuthorCard({ authors }: { authors: string[] }) {
                       width={72}
                       height={72}
                       className="w-[72px] h-[72px] object-contain rounded-lg bg-white p-0.5"
-                      unoptimized={isDev || isExternal(item.image)}
+                      unoptimized={isDev || isExternal(item.image) || shouldBypassImageOptimization(item.image)}
+                      placeholder={shouldBypassImageOptimization(item.image) ? 'empty' : 'blur'}
                     />
                     <figcaption className="text-[10px] font-sans text-muted text-center leading-tight max-w-[72px]">
                       {item.description}

--- a/src/components/AuthorCard.tsx
+++ b/src/components/AuthorCard.tsx
@@ -17,6 +17,9 @@ export default function AuthorCard({ authors }: { authors: string[] }) {
         const slug = getAuthorSlug(author);
         const profile = siteConfig.authors?.[author];
         const hasSocial = profile?.social && profile.social.length > 0;
+        const avatarBypassOptimization = Boolean(
+          profile?.avatar && (isDev || isExternal(profile.avatar) || shouldBypassImageOptimization(profile.avatar))
+        );
 
         return (
           <div
@@ -32,8 +35,8 @@ export default function AuthorCard({ authors }: { authors: string[] }) {
                   width={56}
                   height={56}
                   className="w-14 h-14 rounded-full object-cover flex-shrink-0 ring-2 ring-muted/20"
-                  unoptimized={isDev || isExternal(profile.avatar) || shouldBypassImageOptimization(profile.avatar)}
-                  placeholder={shouldBypassImageOptimization(profile.avatar) ? 'empty' : 'blur'}
+                  unoptimized={avatarBypassOptimization}
+                  placeholder={avatarBypassOptimization ? 'empty' : 'blur'}
                 />
               ) : (
                 <div className="w-14 h-14 rounded-full bg-accent/10 flex items-center justify-center flex-shrink-0 text-accent font-serif font-bold text-2xl select-none">
@@ -62,22 +65,25 @@ export default function AuthorCard({ authors }: { authors: string[] }) {
             {/* Right — social images (e.g. QR codes) */}
             {hasSocial && (
               <div className="flex justify-center gap-5 flex-shrink-0 border-t border-muted/15 pt-4 sm:border-t-0 sm:border-l sm:pt-0 sm:pl-6 sm:justify-start">
-                {profile.social!.map((item, index) => (
-                  <figure key={index} className="flex flex-col items-center gap-1.5">
-                    <ExportedImage
-                      src={item.image}
-                      alt={item.description}
-                      width={72}
-                      height={72}
-                      className="w-[72px] h-[72px] object-contain rounded-lg bg-white p-0.5"
-                      unoptimized={isDev || isExternal(item.image) || shouldBypassImageOptimization(item.image)}
-                      placeholder={shouldBypassImageOptimization(item.image) ? 'empty' : 'blur'}
-                    />
-                    <figcaption className="text-[10px] font-sans text-muted text-center leading-tight max-w-[72px]">
-                      {item.description}
-                    </figcaption>
-                  </figure>
-                ))}
+                {profile.social!.map((item, index) => {
+                  const socialImageBypassOptimization = isDev || isExternal(item.image) || shouldBypassImageOptimization(item.image);
+                  return (
+                    <figure key={index} className="flex flex-col items-center gap-1.5">
+                      <ExportedImage
+                        src={item.image}
+                        alt={item.description}
+                        width={72}
+                        height={72}
+                        className="w-[72px] h-[72px] object-contain rounded-lg bg-white p-0.5"
+                        unoptimized={socialImageBypassOptimization}
+                        placeholder={socialImageBypassOptimization ? 'empty' : 'blur'}
+                      />
+                      <figcaption className="text-[10px] font-sans text-muted text-center leading-tight max-w-[72px]">
+                        {item.description}
+                      </figcaption>
+                    </figure>
+                  );
+                })}
               </div>
             )}
           </div>

--- a/src/components/CoverImage.tsx
+++ b/src/components/CoverImage.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import ExportedImage from 'next-image-export-optimizer';
 import { siteConfig } from '../../site.config';
-import { getCdnImageUrl } from '@/lib/image-utils';
+import { getCdnImageUrl, shouldBypassImageOptimization } from '@/lib/image-utils';
 
 // Each palette defines a gradient background and text color for light/dark modes
 const palettes = [
@@ -88,6 +88,7 @@ export default function CoverImage({ title, slug, src, className = "h-full w-ful
   const imageSrc = getCdnImageUrl(src!, cdnBaseUrl);
   const isCdn = cdnBaseUrl && imageSrc !== src;
   const isDev = process.env.NODE_ENV === 'development';
+  const shouldBypassOptimization = shouldBypassImageOptimization(imageSrc);
 
   return (
     <ExportedImage
@@ -96,7 +97,8 @@ export default function CoverImage({ title, slug, src, className = "h-full w-ful
       className={className}
       fill
       sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
-      unoptimized={isDev || !!isCdn}
+      unoptimized={isDev || !!isCdn || shouldBypassOptimization}
+      placeholder={shouldBypassOptimization ? 'empty' : 'blur'}
       loading={loading}
     />
   );

--- a/src/components/CoverImage.tsx
+++ b/src/components/CoverImage.tsx
@@ -89,6 +89,7 @@ export default function CoverImage({ title, slug, src, className = "h-full w-ful
   const isCdn = cdnBaseUrl && imageSrc !== src;
   const isDev = process.env.NODE_ENV === 'development';
   const shouldBypassOptimization = shouldBypassImageOptimization(imageSrc);
+  const useBlurPlaceholder = !(isDev || !!isCdn || shouldBypassOptimization);
 
   return (
     <ExportedImage
@@ -97,8 +98,8 @@ export default function CoverImage({ title, slug, src, className = "h-full w-ful
       className={className}
       fill
       sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 33vw"
-      unoptimized={isDev || !!isCdn || shouldBypassOptimization}
-      placeholder={shouldBypassOptimization ? 'empty' : 'blur'}
+      unoptimized={!useBlurPlaceholder}
+      placeholder={useBlurPlaceholder ? 'blur' : 'empty'}
       loading={loading}
     />
   );

--- a/src/components/MarkdownRenderer.test.tsx
+++ b/src/components/MarkdownRenderer.test.tsx
@@ -24,6 +24,22 @@ describe("MarkdownRenderer", () => {
       // images as LCP candidates, avoiding "preloaded but not used" warnings
       expect(html).toContain('fetchPriority="low"');
     });
+
+    test("bypasses optimization for local avif images", () => {
+      const content = "![alt text](/images/background-new-wave.avif)";
+      const html = renderToStaticMarkup(<MarkdownRenderer content={content} />);
+      expect(html).toContain('src="/images/background-new-wave.avif"');
+      expect(html).not.toContain('nextImageExportOptimizer');
+      expect(html).not.toContain('background-image:url');
+    });
+
+    test("bypasses optimization for local webp images", () => {
+      const content = "![alt text](/images/already-optimized.webp)";
+      const html = renderToStaticMarkup(<MarkdownRenderer content={content} />);
+      expect(html).toContain('src="/images/already-optimized.webp"');
+      expect(html).not.toContain('nextImageExportOptimizer');
+      expect(html).not.toContain('background-image:url');
+    });
   });
 
   test("adds horizontal overflow containment while preserving code scrolling", () => {

--- a/src/components/MarkdownRenderer.tsx
+++ b/src/components/MarkdownRenderer.tsx
@@ -14,6 +14,7 @@ import remarkWikilinks from '@/lib/remark-wikilinks';
 import ExportedImage from 'next-image-export-optimizer';
 import { PluggableList } from 'unified';
 import type { SlugRegistryEntry } from '@/lib/markdown';
+import { shouldBypassImageOptimization } from '@/lib/image-utils';
 
 
 interface MarkdownRendererProps {
@@ -139,6 +140,7 @@ export default function MarkdownRenderer({ content, latex = false, slug, slugReg
       const isExternal = imageSrc?.startsWith('http') || imageSrc?.startsWith('//');
 
       if (!isExternal) {
+        const shouldBypassOptimization = shouldBypassImageOptimization(imageSrc);
         return (
           <ExportedImage
             src={imageSrc || ''}
@@ -147,7 +149,8 @@ export default function MarkdownRenderer({ content, latex = false, slug, slugReg
             height={height ? Number(height) : 900}
             className="max-w-full h-auto rounded-lg my-4"
             sizes="(max-width: 768px) 100vw, (max-width: 1200px) 80vw, 70vw"
-            unoptimized={isDev}
+            unoptimized={isDev || shouldBypassOptimization}
+            placeholder={shouldBypassOptimization ? 'empty' : 'blur'}
             style={(!width || !height) ? { width: '100%', height: 'auto' } : undefined}
           />
         );

--- a/src/lib/image-utils.test.ts
+++ b/src/lib/image-utils.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, test } from "bun:test";
+import { getCdnImageUrl, shouldBypassImageOptimization } from "./image-utils";
+
+describe("image-utils", () => {
+  test("getCdnImageUrl leaves external and special URLs unchanged", () => {
+    expect(getCdnImageUrl("https://example.com/image.jpg", "https://cdn.example.com")).toBe("https://example.com/image.jpg");
+    expect(getCdnImageUrl("text:Cover", "https://cdn.example.com")).toBe("text:Cover");
+    expect(getCdnImageUrl("data:image/png;base64,abc", "https://cdn.example.com")).toBe("data:image/png;base64,abc");
+  });
+
+  test("shouldBypassImageOptimization skips avif and webp sources", () => {
+    expect(shouldBypassImageOptimization("/images/background-new-wave.avif")).toBe(true);
+    expect(shouldBypassImageOptimization("/images/already-optimized.webp")).toBe(true);
+    expect(shouldBypassImageOptimization("/images/already-optimized.WEBP?version=1")).toBe(true);
+    expect(shouldBypassImageOptimization("/images/photo.jpg")).toBe(false);
+    expect(shouldBypassImageOptimization("/images/photo.png#fragment")).toBe(false);
+  });
+});

--- a/src/lib/image-utils.test.ts
+++ b/src/lib/image-utils.test.ts
@@ -12,6 +12,7 @@ describe("image-utils", () => {
     expect(shouldBypassImageOptimization("/images/background-new-wave.avif")).toBe(true);
     expect(shouldBypassImageOptimization("/images/already-optimized.webp")).toBe(true);
     expect(shouldBypassImageOptimization("/images/already-optimized.WEBP?version=1")).toBe(true);
+    expect(shouldBypassImageOptimization("/images/already-optimized.webp?version=1#hero")).toBe(true);
     expect(shouldBypassImageOptimization("/images/photo.jpg")).toBe(false);
     expect(shouldBypassImageOptimization("/images/photo.png#fragment")).toBe(false);
   });

--- a/src/lib/image-utils.ts
+++ b/src/lib/image-utils.ts
@@ -10,3 +10,14 @@ export function getCdnImageUrl(src: string, cdnBaseUrl: string): string {
   const path = src.startsWith('/') ? src : `/${src}`;
   return `${base}${path}`;
 }
+
+/**
+ * Certain source formats should bypass next-image-export-optimizer entirely.
+ * AVIF currently has an upstream path-generation bug when WEBP output is enabled,
+ * and user-supplied WEBP files are often already optimized enough to serve directly.
+ */
+export function shouldBypassImageOptimization(src: string): boolean {
+  if (!src) return false;
+  const pathWithoutQuery = src.split('#')[0]?.split('?')[0] ?? src;
+  return /\.(avif|webp)$/i.test(pathWithoutQuery);
+}

--- a/src/lib/markdown.test.ts
+++ b/src/lib/markdown.test.ts
@@ -9,6 +9,7 @@ import {
   getHeadings,
   getAuthorSlug,
   getPythonRstRendererAvailabilityForTests,
+  parseMarkdownFileForTests,
   parseRstFileForTests,
   resetPythonRstRendererAvailabilityForTests,
 } from "./markdown";
@@ -157,6 +158,34 @@ describe("markdown utils", () => {
   });
 
   describe("rST parsing fallbacks", () => {
+    test("uses markdown file mtime when frontmatter date and slug date are missing", () => {
+      const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "amytis-md-"));
+      const filePath = path.join(tempDir, "legacy.mdx");
+      fs.writeFileSync(
+        filePath,
+        [
+          "---",
+          'title: "Legacy Markdown"',
+          "---",
+          "",
+          "Body",
+          "",
+        ].join("\n"),
+        "utf8",
+      );
+
+      const expectedDate = "2021-03-17";
+      const expectedTime = new Date(`${expectedDate}T12:00:00Z`);
+      fs.utimesSync(filePath, expectedTime, expectedTime);
+
+      try {
+        const post = parseMarkdownFileForTests(filePath, "legacy");
+        expect(post.date).toBe(expectedDate);
+      } finally {
+        fs.rmSync(tempDir, { recursive: true, force: true });
+      }
+    });
+
     test("includes the source file path in rst parse errors", () => {
       process.env.AMYTIS_ENABLE_PYTHON_RST = "0";
 
@@ -202,6 +231,35 @@ describe("markdown utils", () => {
       expect(post.content).toContain("Overview\n--------");
       expect(post.content).toContain(".. code-block:: ts");
       expect(getPythonRstRendererAvailabilityForTests()).toBe(false);
+    });
+
+    test("uses rst file mtime when metadata date and slug date are missing", () => {
+      process.env.AMYTIS_ENABLE_PYTHON_RST = "0";
+
+      const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "amytis-rst-"));
+      const filePath = path.join(tempDir, "legacy.rst");
+      fs.writeFileSync(
+        filePath,
+        [
+          "Legacy rST",
+          "**********",
+          "",
+          "Body",
+          "",
+        ].join("\n"),
+        "utf8",
+      );
+
+      const expectedDate = "2020-04-09";
+      const expectedTime = new Date(`${expectedDate}T12:00:00Z`);
+      fs.utimesSync(filePath, expectedTime, expectedTime);
+
+      try {
+        const post = parseRstFileForTests(filePath, "legacy");
+        expect(post.date).toBe(expectedDate);
+      } finally {
+        fs.rmSync(tempDir, { recursive: true, force: true });
+      }
     });
   });
 });

--- a/src/lib/markdown.ts
+++ b/src/lib/markdown.ts
@@ -611,7 +611,7 @@ function parseMarkdownFile(fullPath: string, slug: string, dateFromFileName?: st
   
   let date = data.date;
   if (!date && dateFromFileName) date = dateFromFileName;
-  if (!date) date = new Date().toISOString().split('T')[0]; // Fallback
+  if (!date) date = fs.statSync(fullPath).mtime.toISOString().split('T')[0];
 
   const headings = getHeadings(content);
 
@@ -652,6 +652,15 @@ function parseMarkdownFile(fullPath: string, slug: string, dateFromFileName?: st
     imageBaseSlug,
     sourceFormat: 'markdown',
   };
+}
+
+export function parseMarkdownFileForTests(
+  fullPath: string,
+  slug: string,
+  dateFromFileName?: string,
+  seriesName?: string,
+): PostData {
+  return parseMarkdownFile(fullPath, slug, dateFromFileName, seriesName);
 }
 
 function parseRstFile(
@@ -735,7 +744,7 @@ function parseRstFile(
 
     let date = data.date;
     if (!date && dateFromFileName) date = dateFromFileName;
-    if (!date) date = new Date().toISOString().split('T')[0];
+    if (!date) date = fs.statSync(fullPath).mtime.toISOString().split('T')[0];
 
     let coverImage = data.coverImage;
     if (coverImage && !coverImage.startsWith('http') && !coverImage.startsWith('/') && !coverImage.startsWith('text:')) {

--- a/src/lib/markdown.ts
+++ b/src/lib/markdown.ts
@@ -169,6 +169,7 @@ const seriesDataCache = new Map<string, Map<string, PostData | null>>();
 const seriesPostsCache = new Map<string, Map<string, PostData[]>>();
 const allSeriesCache = new Map<string, Record<string, PostData[]>>();
 const featuredSeriesCache = new Map<string, Record<string, PostData[]>>();
+const seriesLatestDateCache = new Map<string, Map<string, string>>();
 const collectionPostsCache = new Map<string, Map<string, PostData[]>>();
 const collectionsForPostCache = new Map<string, Map<string, CollectionContext[]>>();
 const seriesAuthorsCache = new Map<string, Map<string, string[] | null>>();
@@ -1258,6 +1259,25 @@ export function getAllSeries(): Record<string, PostData[]> {
 
   allSeriesCache.set(cacheKey, series);
   return series;
+}
+
+export function getSeriesLatestPostDate(slug: string): string {
+  const cacheKey = getCacheEnvKey();
+  let bySlug = seriesLatestDateCache.get(cacheKey);
+  if (!bySlug) {
+    bySlug = new Map();
+    seriesLatestDateCache.set(cacheKey, bySlug);
+  }
+  const cached = bySlug.get(slug);
+  if (cached !== undefined) return cached;
+
+  const seriesData = getSeriesData(slug);
+  const posts = seriesData?.type === 'collection' ? getCollectionPosts(slug) : getSeriesPosts(slug);
+  const latestPostDate = posts.reduce((latest, post) => (post.date > latest ? post.date : latest), '');
+  const resolved = latestPostDate || seriesData?.date || '';
+
+  bySlug.set(slug, resolved);
+  return resolved;
 }
 
 export function getFeaturedPosts(): PostData[] {

--- a/tests/integration/series.test.ts
+++ b/tests/integration/series.test.ts
@@ -4,6 +4,7 @@ import {
   getAllSeries,
   getAdjacentPosts,
   getSeriesData,
+  getSeriesLatestPostDate,
   getSeriesPosts,
   getFeaturedPosts,
   getFeaturedSeries,
@@ -127,6 +128,12 @@ describe("Integration: Series", () => {
     const posts = getSeriesPosts("rst-toctree");
     expect(posts.map(post => post.slug)).toEqual(["second-post", "first-post"]);
     expect(posts.every(post => post.sourceFormat === "rst")).toBe(true);
+  });
+
+  test("getSeriesLatestPostDate uses the newest post date instead of manual series order", () => {
+    expect(getSeriesData("nextjs-deep-dive")?.sort).toBe("manual");
+    expect(getSeriesPosts("nextjs-deep-dive").map(post => post.date)).toEqual(["2026-01-30", "2026-01-31"]);
+    expect(getSeriesLatestPostDate("nextjs-deep-dive")).toBe("2026-01-31");
   });
 
   test("getAdjacentPosts follows rST series order instead of global post date order", () => {


### PR DESCRIPTION
## Summary
- improve copy-assets diagnostics and turn the sync step into an incremental sync so nested optimizer caches (and source assets) stay intact
- fall back to each file\'s mtime when Markdown or rST posts lack a date
- trim the Next.js image width buckets for a leaner next-image-export-optimizer run
- ensure nested nextImageExportOptimizer directories anywhere under a generated destination are preserved after pruning

## Validation
- bun run lint
- bun test src/lib/markdown.test.ts
- bun scripts/copy-assets.ts && bunx next-image-export-optimizer (two runs)
- bun run build (verified on low-resource VM)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Post date fallback now uses file modification time when frontmatter and filename dates are missing.

* **Improvements**
  * Reduced responsive image sizes for leaner static exports.
  * Smarter asset sync: avoids unnecessary copies, prunes stale files, and removes orphaned optimizer folders.

* **New Features**
  * Series list sorts by each series’ latest post date.
  * Local AVIF/WebP images bypass optimization and use a non-blurred placeholder.

* **Chores**
  * Clean script extended to remove additional image export output.

* **Tests**
  * Added tests for date fallback, series latest-date, image-utils, and image rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->