### PR TITLE
fix: make create-amytis extraction work on windows

### DIFF
--- a/packages/create-amytis/package.json
+++ b/packages/create-amytis/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-amytis",
-  "version": "0.1.0",
+  "version": "0.1.2",
   "description": "Create a new Amytis digital garden",
   "license": "MIT",
   "bin": { "create-amytis": "./dist/index.js" },

--- a/packages/create-amytis/src/index.test.ts
+++ b/packages/create-amytis/src/index.test.ts
@@ -2,7 +2,7 @@ import { describe, test, expect, afterAll } from "bun:test";
 import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
-import { patchSiteConfig, patchPackageJson } from "./index";
+import { getArchiveMetadata, patchSiteConfig, patchPackageJson } from "./index";
 
 // Minimal site.config.ts that mirrors the real file's patchable fields.
 // Inner backticks and `${` are escaped so they appear literally in the string.
@@ -183,5 +183,21 @@ describe("patchPackageJson", () => {
     tmpDirs.push(dir);
     // file intentionally absent
     expect(() => patchPackageJson(dir, "my-garden")).not.toThrow();
+  });
+});
+
+describe("getArchiveMetadata", () => {
+  test("uses zip archives on Windows", () => {
+    const archive = getArchiveMetadata("v1.13.0", "win32");
+    expect(archive.kind).toBe("zip");
+    expect(archive.filename).toBe("amytis-v1.13.0.zip");
+    expect(archive.url).toBe("https://github.com/hutusi/amytis/archive/refs/tags/v1.13.0.zip");
+  });
+
+  test("uses tar.gz archives on non-Windows platforms", () => {
+    const archive = getArchiveMetadata("v1.13.0", "darwin");
+    expect(archive.kind).toBe("tar.gz");
+    expect(archive.filename).toBe("amytis-v1.13.0.tar.gz");
+    expect(archive.url).toBe("https://github.com/hutusi/amytis/archive/refs/tags/v1.13.0.tar.gz");
   });
 });

--- a/packages/create-amytis/src/index.test.ts
+++ b/packages/create-amytis/src/index.test.ts
@@ -2,7 +2,7 @@ import { describe, test, expect, afterAll } from "bun:test";
 import * as fs from "fs";
 import * as os from "os";
 import * as path from "path";
-import { getArchiveMetadata, patchSiteConfig, patchPackageJson } from "./index";
+import { buildExtractCommand, getArchiveMetadata, patchSiteConfig, patchPackageJson } from "./index";
 
 // Minimal site.config.ts that mirrors the real file's patchable fields.
 // Inner backticks and `${` are escaped so they appear literally in the string.
@@ -199,5 +199,31 @@ describe("getArchiveMetadata", () => {
     expect(archive.kind).toBe("tar.gz");
     expect(archive.filename).toBe("amytis-v1.13.0.tar.gz");
     expect(archive.url).toBe("https://github.com/hutusi/amytis/archive/refs/tags/v1.13.0.tar.gz");
+  });
+});
+
+describe("buildExtractCommand", () => {
+  test("builds the PowerShell Expand-Archive command on Windows", () => {
+    const command = buildExtractCommand("C:\\tmp\\amytis-v1.13.0.zip", "C:\\tmp\\my-garden.__tmp__", "zip", "win32");
+    expect(command.command).toBe("powershell.exe");
+    expect(command.args).toEqual([
+      "-NoProfile",
+      "-NonInteractive",
+      "-ExecutionPolicy",
+      "Bypass",
+      "-Command",
+      "Expand-Archive",
+      "-LiteralPath",
+      "C:\\tmp\\amytis-v1.13.0.zip",
+      "-DestinationPath",
+      "C:\\tmp\\my-garden.__tmp__",
+      "-Force",
+    ]);
+  });
+
+  test("builds the tar extraction command on non-Windows platforms", () => {
+    const command = buildExtractCommand("/tmp/amytis-v1.13.0.tar.gz", "/tmp/my-garden.__tmp__", "tar.gz", "darwin");
+    expect(command.command).toBe("tar");
+    expect(command.args).toEqual(["xzf", "/tmp/amytis-v1.13.0.tar.gz", "-C", "/tmp/my-garden.__tmp__"]);
   });
 });

--- a/packages/create-amytis/src/index.ts
+++ b/packages/create-amytis/src/index.ts
@@ -4,7 +4,7 @@ import * as fs from "fs";
 import * as path from "path";
 import * as https from "https";
 import * as readline from "readline";
-import { execFileSync } from "child_process";
+import { execFileSync, execSync } from "child_process";
 
 // ---------------------------------------------------------------------------
 // Helpers

--- a/packages/create-amytis/src/index.ts
+++ b/packages/create-amytis/src/index.ts
@@ -4,7 +4,7 @@ import * as fs from "fs";
 import * as path from "path";
 import * as https from "https";
 import * as readline from "readline";
-import { execFileSync, execSync } from "child_process";
+import { execFileSync } from "child_process";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -97,17 +97,20 @@ export function getArchiveMetadata(tag: string, platform: NodeJS.Platform = proc
   };
 }
 
-function extractArchive(archivePath: string, outDir: string, kind: "zip" | "tar.gz", platform: NodeJS.Platform = process.platform): void {
-  // Extract into a temp dir, then move the inner folder out
-  const tmpDir = `${outDir}.__tmp__`;
-  fs.mkdirSync(tmpDir, { recursive: true });
+export function buildExtractCommand(
+  archivePath: string,
+  tmpDir: string,
+  kind: "zip" | "tar.gz",
+  platform: NodeJS.Platform = process.platform,
+): { command: string; args: string[] } {
   if (kind === "zip") {
     if (platform !== "win32") {
       throw new Error("ZIP extraction is only supported on Windows in create-amytis");
     }
-    execFileSync(
-      "powershell.exe",
-      [
+
+    return {
+      command: "powershell.exe",
+      args: [
         "-NoProfile",
         "-NonInteractive",
         "-ExecutionPolicy",
@@ -120,11 +123,21 @@ function extractArchive(archivePath: string, outDir: string, kind: "zip" | "tar.
         tmpDir,
         "-Force",
       ],
-      { stdio: "inherit" }
-    );
-  } else {
-    execSync(`tar xzf "${archivePath}" -C "${tmpDir}"`);
+    };
   }
+
+  return {
+    command: "tar",
+    args: ["xzf", archivePath, "-C", tmpDir],
+  };
+}
+
+function extractArchive(archivePath: string, outDir: string, kind: "zip" | "tar.gz", platform: NodeJS.Platform = process.platform): void {
+  // Extract into a temp dir, then move the inner folder out
+  const tmpDir = `${outDir}.__tmp__`;
+  fs.mkdirSync(tmpDir, { recursive: true });
+  const { command, args } = buildExtractCommand(archivePath, tmpDir, kind, platform);
+  execFileSync(command, args, { stdio: "inherit" });
 
   // The tarball unpacks to a single top-level dir like "amytis-1.2.0/"
   const entries = fs.readdirSync(tmpDir);

--- a/packages/create-amytis/src/index.ts
+++ b/packages/create-amytis/src/index.ts
@@ -4,7 +4,7 @@ import * as fs from "fs";
 import * as path from "path";
 import * as https from "https";
 import * as readline from "readline";
-import { execSync } from "child_process";
+import { execFileSync, execSync } from "child_process";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -77,11 +77,54 @@ function downloadFile(url: string, dest: string): Promise<void> {
   });
 }
 
-function extractTarball(tarPath: string, outDir: string): void {
+export function getArchiveMetadata(tag: string, platform: NodeJS.Platform = process.platform): {
+  url: string;
+  filename: string;
+  kind: "zip" | "tar.gz";
+} {
+  if (platform === "win32") {
+    return {
+      url: `https://github.com/hutusi/amytis/archive/refs/tags/${tag}.zip`,
+      filename: `amytis-${tag}.zip`,
+      kind: "zip",
+    };
+  }
+
+  return {
+    url: `https://github.com/hutusi/amytis/archive/refs/tags/${tag}.tar.gz`,
+    filename: `amytis-${tag}.tar.gz`,
+    kind: "tar.gz",
+  };
+}
+
+function extractArchive(archivePath: string, outDir: string, kind: "zip" | "tar.gz", platform: NodeJS.Platform = process.platform): void {
   // Extract into a temp dir, then move the inner folder out
   const tmpDir = `${outDir}.__tmp__`;
   fs.mkdirSync(tmpDir, { recursive: true });
-  execSync(`tar xzf "${tarPath}" -C "${tmpDir}"`);
+  if (kind === "zip") {
+    if (platform !== "win32") {
+      throw new Error("ZIP extraction is only supported on Windows in create-amytis");
+    }
+    execFileSync(
+      "powershell.exe",
+      [
+        "-NoProfile",
+        "-NonInteractive",
+        "-ExecutionPolicy",
+        "Bypass",
+        "-Command",
+        "Expand-Archive",
+        "-LiteralPath",
+        archivePath,
+        "-DestinationPath",
+        tmpDir,
+        "-Force",
+      ],
+      { stdio: "inherit" }
+    );
+  } else {
+    execSync(`tar xzf "${archivePath}" -C "${tmpDir}"`);
+  }
 
   // The tarball unpacks to a single top-level dir like "amytis-1.2.0/"
   const entries = fs.readdirSync(tmpDir);
@@ -91,7 +134,7 @@ function extractTarball(tarPath: string, outDir: string): void {
   const innerDir = path.join(tmpDir, entries[0]);
   fs.renameSync(innerDir, outDir);
   fs.rmdirSync(tmpDir);
-  fs.unlinkSync(tarPath);
+  fs.unlinkSync(archivePath);
 }
 
 // ---------------------------------------------------------------------------
@@ -180,14 +223,14 @@ async function main(): Promise<void> {
   console.log(`  Found: ${tag}`);
 
   // 3. Download tarball
-  const tarUrl = `https://github.com/hutusi/amytis/archive/refs/tags/${tag}.tar.gz`;
-  const tarDest = path.join(process.cwd(), `amytis-${tag}.tar.gz`);
+  const archive = getArchiveMetadata(tag);
+  const archiveDest = path.join(process.cwd(), archive.filename);
   console.log("Downloading tarball...");
-  await downloadFile(tarUrl, tarDest);
+  await downloadFile(archive.url, archiveDest);
 
   // 4. Extract
   console.log("Extracting...");
-  extractTarball(tarDest, targetDir);
+  extractArchive(archiveDest, targetDir, archive.kind);
   console.log(`  Scaffolded: ${targetDir}`);
 
   // 5-6. Prompt for site metadata


### PR DESCRIPTION
## Summary
- use the GitHub zip archive for  scaffolding on Windows instead of relying on 
- expand the downloaded archive with PowerShell on  while keeping the existing  flow on other platforms
- bump  to  for the release that includes the Windows extraction fix

## Validation
- bun test v1.3.12 (700fc117)
- 

## Context
This fixes issue #50, where 
Create Amytis — scaffold a new digital garden


Fetching latest Amytis release...
  Found: v1.14.0
Downloading tarball...
Extracting...
  Scaffolded: /Users/hutusi/workspace/ai/naive/amytis-codex/...

Site title (...):  failed on Windows when the release tarball contained Unicode file paths.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Platform-specific archive handling: Windows installers use ZIP; macOS/Linux use tar.gz. Extraction flow updated for more reliable cross-platform installs.

* **Tests**
  * Expanded coverage validating archive format selection and extraction command behavior per operating system.

* **Chores**
  * Package version bumped to 0.1.2.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->