### PR TITLE
fix(ux): strip per-paragraph backgrounds on article copy

### DIFF
--- a/src/components/ArticleCopyCleaner.tsx
+++ b/src/components/ArticleCopyCleaner.tsx
@@ -45,10 +45,11 @@ export default function ArticleCopyCleaner({ children }: { children: ReactNode }
           el.style.removeProperty('background');
         });
 
-        const html = sandbox.innerHTML;
-        const text = selection.toString();
-        event.clipboardData?.setData('text/html', html);
-        event.clipboardData?.setData('text/plain', text);
+        const clipboard = event.clipboardData;
+        if (!clipboard) return;
+
+        clipboard.setData('text/html', sandbox.innerHTML);
+        clipboard.setData('text/plain', selection.toString());
         event.preventDefault();
       } finally {
         sandbox.remove();

--- a/src/components/ArticleCopyCleaner.tsx
+++ b/src/components/ArticleCopyCleaner.tsx
@@ -1,0 +1,63 @@
+'use client';
+
+import { useEffect, useRef, type ReactNode } from 'react';
+
+const KEEP_BG_SELECTOR = 'pre, code, blockquote, .admonition, [class*="admonition"]';
+const STRIP_BG_SELECTOR = 'p, h1, h2, h3, h4, h5, h6, ul, ol, li, div, span, td, th, tr, article, section';
+
+function isMeaningfulBg(value: string): boolean {
+  if (!value) return false;
+  const v = value.trim().toLowerCase();
+  if (v === 'transparent' || v === 'rgba(0, 0, 0, 0)' || v === 'rgb(0, 0, 0, 0)') return false;
+  return true;
+}
+
+export default function ArticleCopyCleaner({ children }: { children: ReactNode }) {
+  const rootRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const root = rootRef.current;
+    if (!root) return;
+
+    const handleCopy = (event: ClipboardEvent) => {
+      const selection = window.getSelection();
+      if (!selection || selection.isCollapsed || selection.rangeCount === 0) return;
+
+      const range = selection.getRangeAt(0);
+      const anchor = range.commonAncestorContainer;
+      if (!(anchor instanceof Node) || !root.contains(anchor)) return;
+
+      const sandbox = document.createElement('div');
+      sandbox.setAttribute('aria-hidden', 'true');
+      sandbox.style.cssText = 'position:fixed;left:-99999px;top:0;visibility:hidden;pointer-events:none;';
+      sandbox.appendChild(range.cloneContents());
+      root.appendChild(sandbox);
+
+      try {
+        sandbox.querySelectorAll<HTMLElement>(KEEP_BG_SELECTOR).forEach((el) => {
+          const bg = getComputedStyle(el).backgroundColor;
+          if (isMeaningfulBg(bg)) el.style.backgroundColor = bg;
+        });
+
+        sandbox.querySelectorAll<HTMLElement>(STRIP_BG_SELECTOR).forEach((el) => {
+          if (el.matches(KEEP_BG_SELECTOR)) return;
+          el.style.removeProperty('background-color');
+          el.style.removeProperty('background');
+        });
+
+        const html = sandbox.innerHTML;
+        const text = selection.toString();
+        event.clipboardData?.setData('text/html', html);
+        event.clipboardData?.setData('text/plain', text);
+        event.preventDefault();
+      } finally {
+        sandbox.remove();
+      }
+    };
+
+    root.addEventListener('copy', handleCopy);
+    return () => root.removeEventListener('copy', handleCopy);
+  }, []);
+
+  return <div ref={rootRef}>{children}</div>;
+}

--- a/src/components/MarkdownRenderer.test.tsx
+++ b/src/components/MarkdownRenderer.test.tsx
@@ -58,9 +58,13 @@ describe("MarkdownRenderer", () => {
     expect(html).toContain("overflow-x-auto");
   });
 
-  test("wraps content in a background container for copy-paste fidelity", () => {
+  test("wraps content in ArticleCopyCleaner so paste output is stripped of per-paragraph backgrounds", () => {
     const content = "Hello world";
     const html = renderToStaticMarkup(<MarkdownRenderer content={content} />);
-    expect(html).toMatch(/class="[^"]*\bbg-background\b[^"]*"/);
+    // The cleaner renders a bare wrapper div; the page background lives on body now,
+    // so the article HTML must not paint its own background (which is what caused
+    // Chromium's clipboard serializer to inline `background-color` on every <p>).
+    expect(html).not.toMatch(/class="[^"]*\bbg-background\b[^"]*"/);
+    expect(html).toContain('<p class="mb-4 leading-relaxed text-foreground">Hello world</p>');
   });
 });

--- a/src/components/MarkdownRenderer.tsx
+++ b/src/components/MarkdownRenderer.tsx
@@ -3,6 +3,7 @@ import RssFeedWidget from '@/components/RssFeedWidget';
 import Mermaid from '@/components/Mermaid';
 import CodeBlock from '@/components/CodeBlock';
 import KatexStyles from '@/components/KatexStyles';
+import ArticleCopyCleaner from '@/components/ArticleCopyCleaner';
 import remarkGfm from 'remark-gfm';
 import rehypeRaw from 'rehype-raw';
 import remarkMath from 'remark-math';
@@ -167,9 +168,9 @@ export default function MarkdownRenderer({ content, latex = false, slug, slugReg
   return (
     <>
     {latex && <KatexStyles />}
-    <div className="bg-background"> {/* Explicit background for better copy-paste fidelity */}
+    <ArticleCopyCleaner>
       <div className="prose prose-lg max-w-none min-w-0 overflow-x-hidden text-foreground
-            prose-headings:font-serif prose-headings:text-heading 
+            prose-headings:font-serif prose-headings:text-heading
             prose-p:text-foreground prose-p:leading-loose
             prose-strong:text-heading prose-strong:font-semibold
             prose-code:bg-muted/15 prose-code:px-1.5 prose-code:py-0.5 prose-code:rounded-md prose-code:border prose-code:border-muted/20 prose-code:text-[0.9em] prose-code:font-medium
@@ -185,7 +186,7 @@ export default function MarkdownRenderer({ content, latex = false, slug, slugReg
           {content}
         </ReactMarkdown>
       </div>
-    </div>
+    </ArticleCopyCleaner>
     </>
   );
 }


### PR DESCRIPTION
## Summary

- When users copy article text and paste it into a rich-text editor (Notion, WeChat, Word, Feishu, Google Docs, …), the destination shows horizontal stripes — Chromium's clipboard serializer inlines the computed `background-color` onto every block element in the selection, so each `<p>` lands with its own background block.
- The April 6 fix (commit `8d4cf2a`) added a `<div className="bg-background">` wrapper around the markdown to mask this. The wrapper itself became the source the serializer read from, so striping returned — especially when copying from dark mode into a light destination.
- This PR replaces the wrapper with a small client component (`ArticleCopyCleaner`) that intercepts `copy` events, builds its own clean clipboard HTML, and `preventDefault()`s the browser's auto-serializer.

## How it works

`ArticleCopyCleaner` mounts a scoped `copy` listener on its DOM subtree. On copy from inside the article:

1. Clones the current `Selection`'s range into a hidden in-tree sandbox `<div>` (so all `.prose` / `dark:` / Tailwind classes resolve via the cascade).
2. Walks elements matched by `pre, code, blockquote, .admonition, [class*="admonition"]` and inlines their computed `background-color` — code blocks and pull-quotes keep their visual distinction when pasted.
3. Walks `p, h1–h6, ul, ol, li, div, span, td, th, tr, article, section` and removes any inline `background-color` / `background` (defensive; the source DOM has none).
4. Writes the cleaned `sandbox.innerHTML` as `text/html` plus the selection's text as `text/plain`, then calls `preventDefault()` — the browser's stripey auto-serializer never runs.
5. Removes the sandbox.

When the selection lies outside the wrapper (e.g. copying from the navbar or sidebar), the handler is a no-op.

The `bg-background` wrapper is removed from `MarkdownRenderer`. The page background continues to come from `body { background-color: var(--background); }` in `src/app/globals.css:441–442`, so on-page rendering is unchanged.

## Files

- **new** `src/components/ArticleCopyCleaner.tsx` — ~60-line client component
- **mod** `src/components/MarkdownRenderer.tsx` — drop `bg-background` wrapper, wrap in `<ArticleCopyCleaner>` instead
- **mod** `src/components/MarkdownRenderer.test.tsx` — flip the previous fix's assertion (article HTML must *not* paint its own background)

## Test plan

- [x] `bun run lint`
- [x] `bun run test:unit` (196 pass)
- [x] `bun run test:int` (82 pass)
- [x] `bun run build:dev` (full static export + Pagefind)
- [ ] **Manual:** copy a selection spanning heading + paragraphs + a code block + a blockquote from a post; paste into Notion / Word / Feishu
  - Light-mode source → light destination: no stripes
  - Dark-mode source → light destination: no dark stripes on paragraphs (the worst-case scenario)
  - Code block and blockquote retain their backgrounds in the paste
- [ ] **Manual:** Cmd+Shift+V (paste as plain text) still produces plain text
- [ ] **Manual:** copying from non-article surfaces (navbar, sidebar) still works as before
- [ ] **Manual:** on-page rendering looks identical to before in both themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved copy-to-clipboard for article content via a new wrapper that preserves important background styling while removing extraneous background styles, resulting in cleaner pasted output.

* **Tests**
  * Updated tests to reflect the refined copy-paste output and explicit paragraph markup expectations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hutusi/amytis/pull/73?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->