### PR TITLE
Post-page rendering polish: hydration, table padding, mermaid frame

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -946,8 +946,16 @@ html.dark .rst-rendered aside.admonition-danger {
  * tables align with surrounding paragraph text. Our `MarkdownRenderer` wraps
  * every table in a bordered container, which makes that zero-padding push
  * content flush against the border. Restore symmetric horizontal padding
- * on every cell so framed tables breathe inside their wrapper. */
-.prose :where(thead th, tbody td, tfoot td):not(:where([class~="not-prose"], [class~="not-prose"] *)) {
+ * on every cell so framed tables breathe inside their wrapper.
+ *
+ * Selector deliberately avoids the plugin's
+ * `.prose :where(...):not(:where(.not-prose, .not-prose *))` shape:
+ * Tailwind v4 / Lightning CSS silently strips user rules that match that
+ * pattern from the compiled bundle (verified by inspecting the built CSS).
+ * Bare descendant selectors survive compilation and have specificity
+ * (0,1,2), beating the plugin's (0,1,0) first/last-child rules
+ * regardless of source order. */
+.prose thead th, .prose tbody td, .prose tfoot td {
   padding-inline: 0.75rem;
 }
 
@@ -955,13 +963,14 @@ html.dark .rst-rendered aside.admonition-danger {
  * that it's interactive. Color it like a link (accent + pointer + hover
  * underline) so it carries the same affordance as other clickable text in
  * prose. The native disclosure marker stays — it's the redundant visual
- * cue that confirms "this expands." */
-.prose :where(summary):not(:where([class~="not-prose"], [class~="not-prose"] *)) {
+ * cue that confirms "this expands." Same selector shape as the cell-padding
+ * override above and for the same reason. */
+.prose summary {
   color: var(--accent);
   cursor: pointer;
 }
 
-.prose :where(summary):not(:where([class~="not-prose"], [class~="not-prose"] *)):hover {
+.prose summary:hover {
   text-decoration: underline;
 }
 

--- a/src/components/MarkdownRenderer.tsx
+++ b/src/components/MarkdownRenderer.tsx
@@ -155,9 +155,7 @@ export default function MarkdownRenderer({ content, latex = false, slug, slugReg
       // We use className presence (e.g. language-js) or newline presence to detect code blocks.
       if (match || isMultiLine) {
         if (language === 'mermaid') {
-          const meta = (props as unknown as Record<string, unknown>)['data-meta'];
-          const compact = typeof meta === 'string' && /(?:^|\s)compact(?:\s|$)/.test(meta);
-          return <Mermaid chart={String(children).replace(/\n$/, '')} compact={compact} />;
+          return <Mermaid chart={String(children).replace(/\n$/, '')} />;
         }
         // react-markdown v10 strips node.data before invoking overrides, so the
         // fence meta is surfaced as a real `data-meta` attribute by rehypeFenceMeta.

--- a/src/components/Mermaid.tsx
+++ b/src/components/Mermaid.tsx
@@ -26,17 +26,13 @@ function installConsoleWarnFilter(): void {
 
 interface MermaidProps {
   chart: string;
-  /** When true (set via the `compact` fence-meta flag in markdown), drops the
-   *  framed wrapper — border, background, padding, shadow — so the SVG can
-   *  use the full column width. Authors opt in per-graph with ```` ```mermaid compact ````. */
-  compact?: boolean;
 }
 
 /**
  * Client-side component for rendering Mermaid charts.
  * Takes a mermaid chart definition string and renders it to SVG.
  */
-const Mermaid: React.FC<MermaidProps> = ({ chart, compact = false }) => {
+const Mermaid: React.FC<MermaidProps> = ({ chart }) => {
   const ref = useRef<HTMLDivElement>(null);
   const [svg, setSvg] = useState<string>("");
   const { theme, systemTheme } = useTheme();
@@ -100,12 +96,8 @@ const Mermaid: React.FC<MermaidProps> = ({ chart, compact = false }) => {
     }
   }, [chart, theme, systemTheme, mounted]);
 
-  const wrapperClass = compact
-    ? "my-6 overflow-x-auto"
-    : "my-8 p-4 md:p-8 rounded-lg border border-muted/20 bg-muted/5 overflow-x-auto shadow-sm";
-
   return (
-    <div className={wrapperClass}>
+    <div className="my-6 overflow-x-auto">
       {/*
         suppressHydrationWarning is intentional: Mermaid runs client-side
         in `useEffect`, injects its SVG via `dangerouslySetInnerHTML`, and

--- a/src/components/PostSidebar.tsx
+++ b/src/components/PostSidebar.tsx
@@ -70,6 +70,10 @@ export default function PostSidebar({ seriesSlug, seriesTitle, posts, collection
   useSidebarAutoScroll(sidebarRef, currentItemRef, currentSlug);
 
   return (
+    // suppressHydrationWarning on locale-bound nodes is a band-aid for the
+    // known static-export + client-i18n drift: SSR renders defaultLocale,
+    // `useLanguage()` hook serves the user's saved locale on hydration. The
+    // real fix is per-locale URL routing, tracked as a separate refactor.
     <aside
       ref={sidebarRef}
       data-testid="post-sidebar"
@@ -87,7 +91,10 @@ export default function PostSidebar({ seriesSlug, seriesTitle, posts, collection
           {/* Header — always visible */}
           <div className="mb-3">
             <div className="flex items-center justify-between mb-1">
-              <span className="text-[10px] font-sans font-bold uppercase tracking-widest text-accent">
+              <span
+                className="text-[10px] font-sans font-bold uppercase tracking-widest text-accent"
+                suppressHydrationWarning
+              >
                 {isCollectionContext ? t('collection') : t('series')}
               </span>
               <span className="text-[10px] font-mono text-muted/60">
@@ -172,6 +179,7 @@ export default function PostSidebar({ seriesSlug, seriesTitle, posts, collection
               <Link
                 href={`/series/${effectiveSlug}`}
                 className="text-xs font-sans text-muted hover:text-accent transition-colors no-underline flex items-center gap-1"
+                suppressHydrationWarning
               >
                 {isCollectionContext ? t('view_full_collection') : t('view_full_series')}
                 <svg className="w-3 h-3" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
@@ -185,7 +193,10 @@ export default function PostSidebar({ seriesSlug, seriesTitle, posts, collection
 
       {shareUrl && siteConfig.share?.enabled && (
         <div className="mt-6 pt-6 border-t border-muted/10">
-          <p className="text-[10px] font-sans font-bold uppercase tracking-widest text-muted mb-3">
+          <p
+            className="text-[10px] font-sans font-bold uppercase tracking-widest text-muted mb-3"
+            suppressHydrationWarning
+          >
             {t('share_post')}
           </p>
           <ShareBar url={shareUrl} title={shareTitle ?? ''} />

--- a/src/components/ShareBar.tsx
+++ b/src/components/ShareBar.tsx
@@ -77,6 +77,10 @@ export default function ShareBar({ url, title, className = '' }: ShareBarProps) 
   const btnClass = 'inline-flex items-center justify-center w-8 h-8 rounded text-muted hover:text-accent hover:bg-muted/10 transition-colors';
 
   return (
+    // suppressHydrationWarning on locale-bound nodes is a band-aid for the
+    // known static-export + client-i18n drift: SSR renders defaultLocale,
+    // `useLanguage()` hook serves the user's saved locale on hydration. The
+    // real fix is per-locale URL routing, tracked as a separate refactor.
     <div className={`flex flex-row flex-wrap gap-1 ${className}`}>
       {platforms.map((platform) => {
         const { label, Icon } = PLATFORM_META[platform];
@@ -90,6 +94,7 @@ export default function ShareBar({ url, title, className = '' }: ShareBarProps) 
               title={copyLabel}
               aria-label={copyLabel}
               className={`${btnClass} ${copied ? 'text-accent' : ''}`}
+              suppressHydrationWarning
             >
               {copied ? <LuCheck size={16} /> : <Icon size={16} />}
             </button>

--- a/tests/integration/code-block-features.test.ts
+++ b/tests/integration/code-block-features.test.ts
@@ -68,33 +68,35 @@ describe('Integration: Code Block Features', () => {
       return m?.[1] ?? '';
     };
 
-    test('mermaid default fence renders with the framed wrapper', async () => {
+    test('mermaid renders with a frameless wrapper (no border/padding/shadow)', async () => {
+      // Mermaid SVG nodes carry their own borders, so the prose pipeline does
+      // not wrap diagrams in a framed container the way it wraps tables.
       const content = ['```mermaid', 'graph TD; A-->B;', '```'].join('\n');
       const html = await renderAsync(MarkdownRenderer({ content }));
       const wrapper = findMermaidWrapperClass(html);
 
-      expect(wrapper).toContain('my-8');
-      expect(wrapper).toContain('p-4');
-      expect(wrapper).toContain('md:p-8');
-      expect(wrapper).toContain('shadow-sm');
-      expect(wrapper).toContain('border');
-    });
-
-    test('mermaid `compact` fence meta drops the framed wrapper', async () => {
-      const content = ['```mermaid compact', 'graph TD; A-->B;', '```'].join('\n');
-      const html = await renderAsync(MarkdownRenderer({ content }));
-      const wrapper = findMermaidWrapperClass(html);
-
-      // `compact` swaps to a frameless wrapper (my-6 + overflow only, no
-      // padding / border / shadow) so the SVG can use the full column width.
       expect(wrapper).toContain('my-6');
       expect(wrapper).toContain('overflow-x-auto');
       expect(wrapper).not.toContain('shadow-sm');
       expect(wrapper).not.toContain('p-4');
       expect(wrapper).not.toContain('md:p-8');
       expect(wrapper).not.toContain('border');
-      // Still wrapped — assert the inner mermaid container is present.
       expect(html.toLowerCase()).toContain('mermaid');
+    });
+
+    test('legacy `compact` fence meta is a no-op (no regression for old content)', async () => {
+      // ` ```mermaid compact ` used to opt out of a framed wrapper that no
+      // longer exists. The flag stays unrecognised by the pipeline and must
+      // render identically to a bare ` ```mermaid ` fence — otherwise the 52
+      // historical `compact` blocks in `content/` would regress.
+      const bare = await renderAsync(
+        MarkdownRenderer({ content: ['```mermaid', 'graph TD; A-->B;', '```'].join('\n') }),
+      );
+      const withCompact = await renderAsync(
+        MarkdownRenderer({ content: ['```mermaid compact', 'graph TD; A-->B;', '```'].join('\n') }),
+      );
+
+      expect(findMermaidWrapperClass(withCompact)).toBe(findMermaidWrapperClass(bare));
     });
 
     test('unknown language renders as plaintext (warn-and-degrade)', async () => {


### PR DESCRIPTION
## Summary

Three small post-page rendering fixes batched together. All three surfaced from opening posts/books in the browser; none of them are caught by `lint`/`test`.

- **`fix(i18n)`** — `suppressHydrationWarning` on locale-bound text in `PostSidebar` and `ShareBar`. Same class of bug 054feed patched for `TocPanel`/`PostNavigation`: SSR renders `defaultLocale` (en), `useLanguage()` swaps to the localStorage locale (zh) on hydration, React bails on the first diff with a console error pointing at the share-section `<p>{t('share_post')}</p>` (and the two sibling spans/links).
- **`fix(css)`** — restore horizontal padding on prose table cells. The override at `globals.css:945` was silently stripped from the compiled bundle by Tailwind v4 / Lightning CSS (verified by grepping the served `_next/static/chunks/*.css`) because its `:where()`/`:not()` selector shape matches the plugin-generated form. Rewriting as bare `.prose thead th, .prose tbody td, .prose tfoot td` survives compilation and beats Typography's `:first-child{padding-inline-start:0}` on specificity. Same rewrite for the `.prose summary` override, which was also missing from the bundle.
- **`refactor(mermaid)`** — drop the framed wrapper and the `compact` opt-out. 52 of 79 mermaid blocks (66%) in `content/` were already using `compact`; the default was working against its own users. Mermaid SVG nodes carry their own borders and shapes, unlike raw HTML tables. Removed the prop end-to-end; existing `` ```mermaid compact `` fences keep rendering fine (unrecognised fence meta is a no-op).

## Test plan

- [x] `bun run lint` clean
- [x] `bun test` — same pass/fail counts as main (96 pre-existing failures from cross-file test-ordering interference; same files pass in isolation)
- [x] **i18n**: set `localStorage['amytis-language'] = 'zh'`, reload `/posts/code-block-features-showcase/`, confirm no hydration error in console. Toggle back to `en`, confirm clean.
- [x] **table padding**: open `/books/dmla/language-models/architecture-basics/transformer-architecture/`, confirm first/last column cells have breathing room from the table border. Verified `.prose thead th, .prose tbody td, .prose tfoot td { padding-inline: .75rem }` now lands in the served CSS bundle.
- [x] **mermaid frame**: open `/posts/code-block-features-showcase/`, confirm diagrams render without the outer rounded border/background/padding. Confirmed SSR fragment emits `class="my-6 overflow-x-auto"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed SSR/client locale hydration mismatches in the post sidebar and share components to prevent locale-related display inconsistencies.

* **Refactor**
  * Mermaid diagrams: removed legacy compact mode—diagrams now render with a single consistent layout.
  * Simplified typography styling for framed tables and summary elements for more consistent presentation.

* **Tests**
  * Updated integration tests to verify the new Mermaid rendering behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->