### PR TITLE
fix(immersive): scroll heading anchors inside the overlay's scroll container

### DIFF
--- a/src/lib/scroll-utils.ts
+++ b/src/lib/scroll-utils.ts
@@ -1,11 +1,49 @@
 import type React from 'react';
 
-export function scrollToHeading(e: React.MouseEvent<HTMLAnchorElement>, id: string): void {
-  const element = document.getElementById(id);
-  if (element) {
-    e.preventDefault();
-    const elementPosition = element.getBoundingClientRect().top + window.scrollY;
-    window.scrollTo({ top: elementPosition - 80, behavior: 'smooth' });
-    history.pushState(null, '', `#${id}`);
+const HEADING_OFFSET_PX = 80;
+
+/**
+ * Walks up from `el` looking for the closest ancestor that actually scrolls
+ * vertically. Returns `null` if the document/window is the scroll container —
+ * that's the normal-page case; immersive reading mode is the case where this
+ * returns the overlay's `<main>` element. The `scrollHeight > clientHeight`
+ * guard skips `overflow:auto` boxes that aren't currently overflowing (e.g.
+ * the overlay's sidebar `<aside>` or the article wrapper).
+ */
+function getScrollableAncestor(el: HTMLElement): HTMLElement | null {
+  let cur: HTMLElement | null = el.parentElement;
+  while (cur && cur !== document.documentElement) {
+    const { overflowY } = window.getComputedStyle(cur);
+    if (
+      (overflowY === 'auto' || overflowY === 'scroll') &&
+      cur.scrollHeight > cur.clientHeight
+    ) {
+      return cur;
+    }
+    cur = cur.parentElement;
   }
+  return null;
+}
+
+export function scrollToHeading(
+  e: React.MouseEvent<HTMLAnchorElement>,
+  id: string,
+): void {
+  const element = document.getElementById(id);
+  if (!element) return;
+  e.preventDefault();
+
+  const container = getScrollableAncestor(element);
+  if (container) {
+    const elRect = element.getBoundingClientRect();
+    const containerRect = container.getBoundingClientRect();
+    const top =
+      elRect.top - containerRect.top + container.scrollTop - HEADING_OFFSET_PX;
+    container.scrollTo({ top, behavior: 'smooth' });
+  } else {
+    const top =
+      element.getBoundingClientRect().top + window.scrollY - HEADING_OFFSET_PX;
+    window.scrollTo({ top, behavior: 'smooth' });
+  }
+  history.pushState(null, '', `#${id}`);
 }


### PR DESCRIPTION
## Summary

- In immersive reading mode, clicking a sidebar TOC link (e.g. `#微积分基本定理` on `/books/dmla/maths/calculus/gradient/`) did nothing — works fine in normal mode.
- `scrollToHeading` unconditionally called `window.scrollTo`, but `ImmersiveReadingProvider` locks `body.overflow: hidden` while the overlay is open; the chapter content actually scrolls inside `ImmersiveReader`'s inner `<main>` (the only `overflow-y-auto` container).
- Walk up from the heading to find the nearest ancestor that actually scrolls vertically (`overflowY: auto|scroll` AND `scrollHeight > clientHeight`, so a non-overflowing `overflow:auto` wrapper isn't picked) and scroll *that* element. Falls back to `window.scrollTo` for normal mode, preserving `/posts/...` (`TocPanel`) and non-immersive book chapters.

## Test plan

- [ ] `bun dev`, open `/books/dmla/maths/calculus/gradient/` in normal mode, click a sidebar subheading → page scrolls to it.
- [ ] Enter immersive mode on the same chapter, click the same subheading → overlay's `<main>` scrolls to it. Try both ASCII and Unicode ids.
- [ ] Exit immersive mode and repeat the first step → still works (no regression).
- [ ] Spot-check `/posts/...` with a long TOC → anchor clicks still work.
- [x] `bun run lint && bun run test`