### PR TITLE
fix(immersive): sidebar active heading tracks the overlay's scroll

### DIFF
--- a/src/hooks/useActiveHeading.ts
+++ b/src/hooks/useActiveHeading.ts
@@ -2,11 +2,12 @@
 
 import { useState, useEffect } from 'react';
 import type { Heading } from '@/lib/markdown';
-import { useScrollY } from './useScrollY';
+import { getScrollableAncestor } from '@/lib/scroll-utils';
+
+const ACTIVATION_LINE_PX = 100;
 
 export function useActiveHeading(headings: Heading[], enabled = true): string {
   const [activeId, setActiveId] = useState('');
-  const scrollY = useScrollY();
 
   useEffect(() => {
     if (!enabled || headings.length === 0) return;
@@ -14,19 +15,40 @@ export function useActiveHeading(headings: Heading[], enabled = true): string {
     const elements = headings
       .map(h => document.getElementById(h.id))
       .filter(Boolean) as HTMLElement[];
-
     if (elements.length === 0) return;
 
-    const scrollPosition = scrollY + 100;
-    let current = elements[0];
-    for (const el of elements) {
-      if (el.offsetTop <= scrollPosition) current = el;
-      else break;
-    }
+    // In immersive reading mode the chapter scrolls inside the overlay's
+    // <main>, not the window, so subscribe to whichever ancestor is doing
+    // the scrolling. `getScrollableAncestor` returns null for normal pages.
+    const container = getScrollableAncestor(elements[0]);
+    const target: HTMLElement | Window = container ?? window;
 
-    const rafId = requestAnimationFrame(() => { if (current) setActiveId(current.id); });
-    return () => cancelAnimationFrame(rafId);
-  }, [scrollY, headings, enabled]);
+    let rafId = 0;
+    const compute = () => {
+      const containerTop = container
+        ? container.getBoundingClientRect().top
+        : 0;
+      let current = elements[0];
+      for (const el of elements) {
+        const top = el.getBoundingClientRect().top - containerTop;
+        if (top <= ACTIVATION_LINE_PX) current = el;
+        else break;
+      }
+      setActiveId(current.id);
+    };
+
+    const onScroll = () => {
+      cancelAnimationFrame(rafId);
+      rafId = requestAnimationFrame(compute);
+    };
+
+    compute();
+    target.addEventListener('scroll', onScroll, { passive: true });
+    return () => {
+      cancelAnimationFrame(rafId);
+      target.removeEventListener('scroll', onScroll);
+    };
+  }, [enabled, headings]);
 
   return activeId;
 }

--- a/src/lib/scroll-utils.ts
+++ b/src/lib/scroll-utils.ts
@@ -10,7 +10,7 @@ const HEADING_OFFSET_PX = 80;
  * guard skips `overflow:auto` boxes that aren't currently overflowing (e.g.
  * the overlay's sidebar `<aside>` or the article wrapper).
  */
-function getScrollableAncestor(el: HTMLElement): HTMLElement | null {
+export function getScrollableAncestor(el: HTMLElement): HTMLElement | null {
   let cur: HTMLElement | null = el.parentElement;
   while (cur && cur !== document.documentElement) {
     const { overflowY } = window.getComputedStyle(cur);


### PR DESCRIPTION
## Summary

- Companion to #98. In immersive reading mode, the sidebar TOC active-heading highlight froze and never updated as the reader scrolled.
- Two reasons in `useActiveHeading`: it listened to `window.scrollY` via `useScrollY` (the window doesn't scroll while the overlay is open — `body.overflow: hidden`), and it used `el.offsetTop` which becomes relative to the fixed-positioned overlay div (a static value compared against a fixed-zero scrollY).
- Detect the heading's nearest scrollable ancestor (reuse `getScrollableAncestor` exported from `scroll-utils.ts`) and subscribe to *its* `scroll` event; fall back to `window` for normal-mode pages. Switch the math to `getBoundingClientRect()` deltas so it works against whichever container is scrolling. rAF-throttled.
- `ReadingProgressBar` still uses `useScrollY` for the document-level progress bar — unaffected (and hidden in immersive mode).

## Test plan

- [ ] `bun dev`, open `/books/dmla/maths/calculus/gradient/`.
- [ ] Normal mode: scroll, sidebar active heading tracks (regression).
- [ ] Immersive mode: scroll the overlay, sidebar active heading tracks. Try the very top and very bottom of the chapter.
- [ ] Click a sidebar link in immersive mode → #98 scroll still works AND the clicked heading becomes active.
- [ ] `/posts/...` with a long TOC — highlight still tracks scroll in normal mode.
- [x] `bun run lint && bun run test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved active heading detection mechanism with enhanced scroll performance optimization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->