### PR TITLE
fix(immersive): preserve overlay when navigating across a collection

### DIFF
--- a/src/components/ImmersiveSeriesSidebar.tsx
+++ b/src/components/ImmersiveSeriesSidebar.tsx
@@ -5,6 +5,7 @@ import { useSearchParams } from 'next/navigation';
 import Link from 'next/link';
 import type { PostData, CollectionContext, Heading } from '@/lib/markdown';
 import { useLanguage } from './LanguageProvider';
+import { useImmersiveReading } from './ImmersiveReadingProvider';
 import { useSidebarAutoScroll } from '@/hooks/useSidebarAutoScroll';
 import InlineBookToc from './InlineBookToc';
 import { getPostUrl, getPostUrlInCollection, getSeriesListUrl, getSeriesUrl } from '@/lib/urls';
@@ -38,6 +39,7 @@ export default function ImmersiveSeriesSidebar({
   headings = [],
 }: ImmersiveSeriesSidebarProps) {
   const { t } = useLanguage();
+  const { enabled: immersiveEnabled } = useImmersiveReading();
   const searchParams = useSearchParams();
   const collectionParam = searchParams.get('collection');
   const activeCollection = collectionParam
@@ -49,8 +51,19 @@ export default function ImmersiveSeriesSidebar({
   const effectivePosts = activeCollection?.posts ?? posts;
   const isCollectionContext = !!activeCollection;
 
-  const postHref = (post: PostData) =>
-    activeCollection ? getPostUrlInCollection(post, activeCollection.slug) : getPostUrl(post);
+  // Collections mix posts from different layout segments (`/posts/[slug]` vs
+  // `/[series]/[slug]`). When clicking across that boundary, the
+  // ImmersiveReadingProvider remounts with `enabled=false` and the overlay
+  // closes. Appending `?immersive=1` lets the destination layout's
+  // ImmersiveReadingFlagHandler re-enter the reader and strip the flag.
+  const postHref = (post: PostData) => {
+    const base = activeCollection
+      ? getPostUrlInCollection(post, activeCollection.slug)
+      : getPostUrl(post);
+    if (!immersiveEnabled) return base;
+    const sep = base.includes('?') ? '&' : '?';
+    return `${base}${sep}immersive=1`;
+  };
 
   const currentIndex = effectivePosts.findIndex(p => p.slug === currentSlug);
   const currentItemRef = useRef<HTMLLIElement>(null);


### PR DESCRIPTION
## Summary

- Reading a post in a collection-type series, opening the immersive reader, then clicking another post in the sidebar → the overlay closed. Reproducible because collections mix posts from heterogeneous layout segments — standalones at `/posts/[slug]` and series posts at `/[series]/[slug]`.
- `ImmersiveReadingProvider` is mounted at each segment (intentional — a single root-level provider would leak `enabled=true` to pages without a reader shell). Cross-segment navigation remounts the provider with `enabled=false`.
- The handshake for this already exists: `ImmersiveReadingFlagHandler` re-enters the reader when it sees `?immersive=1` and strips the flag. The book-index CTA uses it; the collection sidebar didn't. Append the flag in `ImmersiveSeriesSidebar`'s `postHref` when `enabled` is true.
- Idempotent — `enter()` is a no-op when already enabled, so adding the flag doesn't disturb within-layout navigation. Series/collection header link and "All Series" footer link are intentional exits and stay flag-free.

## Test plan

- [ ] `bun dev`. Open a collection-type series (e.g. `modern-web-dev`) on a post that lives at `/posts/[slug]`. Enter immersive mode.
- [ ] Click a sidebar post that lives at `/[series]/[slug]` → overlay stays open on the new post (the fix).
- [ ] From there, click back to a `/posts/[slug]` member → overlay stays open.
- [ ] Click the collection title (header) or "All Series" (footer) → overlay exits (intended).
- [ ] Sequential auto-pathed series (no collection): overlay still persists across sidebar clicks (regression).
- [ ] Exit immersive, then click a sidebar link → lands in normal mode, no `?immersive=1` in the URL.
- [x] `bun run lint && bun run test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Immersive reading mode now persists when navigating between posts via the sidebar, eliminating the need to re-enable reading mode after each post selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->