### PR TITLE
chore: pin Vercel build settings via vercel.json

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "framework": "nextjs",
+  "buildCommand": "bun run build",
+  "installCommand": "bun install",
+  "outputDirectory": "out"
+}

--- a/vercel.json
+++ b/vercel.json
@@ -2,6 +2,6 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "framework": "nextjs",
   "buildCommand": "bun run build",
-  "installCommand": "bun install",
+  "installCommand": "bun install --frozen-lockfile",
   "outputDirectory": "out"
 }


### PR DESCRIPTION
## Summary

- Add `vercel.json` pinning Framework Preset, Build Command, Install Command, and Output Directory so forks deploy on Vercel without touching the dashboard.
- Triggered by a fork failing with `bun build: Missing entrypoints` — Vercel had inferred the literal command `bun build` (Bun's bundler) instead of `bun run build` (the script in package.json).

## Why these specific values

- `framework: nextjs` — keeps the Next.js integration on (image/font handling, log labeling).
- `buildCommand: bun run build` — runs the real pipeline (copy-assets → graph → next build → image optimizer → Pagefind). `next build` alone would skip the image optimizer and search index.
- `installCommand: bun install` — matches `packageManager: bun@1.3.11` in package.json.
- `outputDirectory: out` — required because `next.config.ts` uses `output: "export"` + `trailingSlash: true`, so the static export lands in `out/`, not `.next/`.

## Test plan

- [ ] Vercel preview build for this PR completes successfully and the preview URL renders the homepage, a post route, and search results (Pagefind index loads under `/pagefind/`).
- [ ] Forks importing the repo into Vercel now get the four settings auto-applied (no manual override needed).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated deployment configuration to use Next.js with Bun for builds and installations, streamlining build/output handling for faster, more consistent deployments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->