### PR TITLE
fix(books): normalize no-space VuePress container openers with titles

### DIFF
--- a/src/lib/remark-vuepress-containers.ts
+++ b/src/lib/remark-vuepress-containers.ts
@@ -1,22 +1,39 @@
 import { visit } from 'unist-util-visit';
 import type { Root } from 'mdast';
 
-const CONTAINER_OPENER_RE = /^:::[ \t]+([a-zA-Z][\w-]*)(?:[ \t]+([^\n]+))?[ \t]*$/;
+// Space form: `::: name [optional title]`. The space makes the whole line
+// invisible to remark-directive, so it must always be rewritten.
+const SPACED_OPENER_RE = /^:::[ \t]+([a-zA-Z][\w-]*)(?:[ \t]+([^\n]+))?[ \t]*$/;
+// No-space form WITH a bare title: `:::name Some title`. remark-directive
+// accepts `:::name` but rejects bare text after the name, so without
+// rewriting, the line falls through as literal paragraph text. A bare
+// `:::name` (e.g. `:::code-group`) is already valid directive syntax and a
+// canonical `:::name[title]` must not be touched — the `[^\n[{]` first title
+// character excludes both label (`[`) and attribute (`{`) openers.
+const BARE_TITLE_OPENER_RE = /^:::([a-zA-Z][\w-]*)[ \t]+([^\n[{][^\n]*?)[ \t]*$/;
 const FENCE_OPEN_RE = /^[ \t]*(`{3,}|~{3,})/;
 
 function normalizeContainerLine(line: string): string {
-  return line.replace(
-    CONTAINER_OPENER_RE,
-    (_match, name: string, label: string | undefined) =>
-      label ? `:::${name}[${label.trim()}]` : `:::${name}`,
-  );
+  const spaced = line.match(SPACED_OPENER_RE);
+  if (spaced) {
+    const [, name, label] = spaced;
+    return label ? `:::${name}[${label.trim()}]` : `:::${name}`;
+  }
+  const bareTitle = line.match(BARE_TITLE_OPENER_RE);
+  if (bareTitle) {
+    const [, name, label] = bareTitle;
+    return `:::${name}[${label.trim()}]`;
+  }
+  return line;
 }
 
 /**
- * Pre-process VuePress's relaxed container opener (`::: name [optional title]`)
- * into remark-directive's canonical form (`:::name[title]`). The Markdown spec
- * variant remark-directive recognizes is space-less; the dmla source — and
- * VuePress in general — uses a space-after-colons style with an inline title.
+ * Pre-process VuePress's relaxed container openers into remark-directive's
+ * canonical form (`:::name[title]`). VuePress accepts both a spaced style
+ * (`::: name [optional title]`, used by the dmla source) and a no-space style
+ * with a bare inline title (`:::name Some title`, used by the fenix source);
+ * remark-directive recognizes neither — the spaced form isn't a directive at
+ * all, and bare text after the name disqualifies the no-space form.
  *
  * Skips fenced code blocks (`` ``` `` / `~~~`) so a documentation example that
  * shows VuePress container syntax verbatim doesn't get rewritten as if it were

--- a/tests/integration/vuepress-containers.test.ts
+++ b/tests/integration/vuepress-containers.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import MarkdownRenderer from "@/components/MarkdownRenderer";
 import { renderAsync } from "@/test-utils/render";
+import { normalizeVuepressContainerSyntax } from "@/lib/remark-vuepress-containers";
 
 describe("Integration: VuePress :::container alerts", () => {
   test(":::note renders as a note GitHub Alert", async () => {
@@ -86,6 +87,42 @@ describe("Integration: VuePress :::container alerts", () => {
     // The real container outside the code block still renders as an alert.
     expect(html).toContain('class="alert alert-tip"');
     expect(html).toContain("真实的提示");
+  });
+
+  test("no-space opener with a bare title (fenix style) renders an alert with the custom title", async () => {
+    // VuePress also accepts `:::tip Some title` (no space after the colons).
+    // remark-directive rejects bare text after the name, so without
+    // normalization this line falls through as literal paragraph text.
+    const html = await renderAsync(
+      MarkdownRenderer({
+        content: [
+          ":::tip 无服务架构（Serverless）",
+          "",
+          "如果说微服务架构是分布式系统这条路的极致。",
+          "",
+          ":::",
+        ].join("\n"),
+      }),
+    );
+    expect(html).toContain('class="alert alert-tip"');
+    expect(html).toContain("无服务架构（Serverless）");
+    expect(html).toContain("如果说微服务架构是分布式系统这条路的极致。");
+    expect(html).not.toContain(":::");
+  });
+
+  test("normalizer rewrites only the forms remark-directive cannot parse", () => {
+    // Spaced forms (always rewritten)
+    expect(normalizeVuepressContainerSyntax("::: tip Some Title")).toBe(":::tip[Some Title]");
+    expect(normalizeVuepressContainerSyntax("::: warning")).toBe(":::warning");
+    // No-space form with a bare title (rewritten — the fenix style)
+    expect(normalizeVuepressContainerSyntax(":::tip 无服务架构（Serverless）"))
+      .toBe(":::tip[无服务架构（Serverless）]");
+    // Already-valid directive syntax (untouched)
+    expect(normalizeVuepressContainerSyntax(":::code-group")).toBe(":::code-group");
+    expect(normalizeVuepressContainerSyntax(":::tip")).toBe(":::tip");
+    expect(normalizeVuepressContainerSyntax(":::tip[已有标题]")).toBe(":::tip[已有标题]");
+    expect(normalizeVuepressContainerSyntax(":::tip{.classy}")).toBe(":::tip{.classy}");
+    expect(normalizeVuepressContainerSyntax(":::")).toBe(":::");
   });
 
   test("fence character type matters (~~~ vs ```)", async () => {


### PR DESCRIPTION
## Summary

Reported on `books/fenix/architecture/architect-history/serverless/`: `:::tip 无服务架构（Serverless）` rendered as literal paragraph text instead of a tip callout.

**Root cause:** VuePress accepts two relaxed container opener styles — `::: tip Title` (spaced) and `:::tip Title` (no space, bare title). The pre-parse normalizer in `src/lib/remark-vuepress-containers.ts` only rewrote the spaced form into remark-directive's canonical `:::name[title]`. The no-space-with-title form matched neither the normalizer nor remark-directive (which rejects bare text after a directive name), so the opener and its closing `:::` fell through as visible text. The fenix book uses this form **213 times**; the spaced form (69 uses) was unaffected.

**Fix:** a second normalizer pattern canonicalizes `:::name Bare title` → `:::name[title]`. Already-valid directive syntax is deliberately untouched: bare `:::name` (e.g. `:::code-group`), `:::name[label]`, `:::name{attrs}`, closing `:::`, and anything inside fenced code blocks (the existing fence tracker still applies).

## Testing

- New cases in `tests/integration/vuepress-containers.test.ts`: full-pipeline render of the fenix-style opener (alert + custom title, no literal `:::` leaks) and a string-level table covering all rewrite/no-rewrite forms.
- `bun run lint && bun run test` green (358 unit + 225 integration, 0 fail).
- Dev-server verification on the reported chapter: literal `:::` gone from the body, `alert alert-tip` rendered with the custom title.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced VuePress container syntax parsing to support flexible spacing variants (`::: name [title]` and `:::name title` forms), ensuring proper conversion to GitHub-style alerts with custom titles.

* **Tests**
  * Added comprehensive test coverage for VuePress container syntax variants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->