### PR TITLE
perf: widen and re-space immersive reader width options

### DIFF
--- a/src/components/ImmersiveReader.tsx
+++ b/src/components/ImmersiveReader.tsx
@@ -16,16 +16,16 @@ const FONT_SIZE_REM: Record<ReadingFontSize, string> = {
 };
 
 const COLUMN_WIDTH_CLASS: Record<ReadingColumnWidth, string> = {
-  narrow: 'max-w-2xl',
-  medium: 'max-w-3xl',
-  wide: 'max-w-4xl',
-  full: 'max-w-none',
+  narrow: 'max-w-2xl', //  672px — comfortable focused column
+  medium: 'max-w-4xl', //  896px
+  wide: 'max-w-[88rem]', // 1408px — default; fills a widescreen without going edge-to-edge
+  full: 'max-w-none', //  unconstrained
 };
 
 const COLUMN_PADDING_CLASS: Record<ReadingColumnWidth, string> = {
   narrow: 'px-6 sm:px-8',
   medium: 'px-6 sm:px-8',
-  wide: 'px-6 sm:px-8',
+  wide: 'px-6 sm:px-10',
   full: 'px-6 sm:px-10',
 };
 

--- a/src/components/ImmersiveReadingPrefsPopover.tsx
+++ b/src/components/ImmersiveReadingPrefsPopover.tsx
@@ -39,9 +39,9 @@ const THEME_OPTIONS: Array<{ value: ReadingTheme; labelKey: TranslationKey }> = 
 ];
 
 const WIDTH_OPTIONS: Array<{ value: ReadingColumnWidth; labelKey: TranslationKey; barWidthPct: number }> = [
-  { value: 'narrow', labelKey: 'width_narrow', barWidthPct: 35 },
-  { value: 'medium', labelKey: 'width_medium', barWidthPct: 55 },
-  { value: 'wide', labelKey: 'width_wide', barWidthPct: 75 },
+  { value: 'narrow', labelKey: 'width_narrow', barWidthPct: 40 },
+  { value: 'medium', labelKey: 'width_medium', barWidthPct: 60 },
+  { value: 'wide', labelKey: 'width_wide', barWidthPct: 80 },
   { value: 'full', labelKey: 'width_full', barWidthPct: 100 },
 ];
 


### PR DESCRIPTION
## Why

The immersive reader's four width buckets were bunched at the low end (`narrow`/`medium`/`wide` = 672/768/896px, only 96–128px apart) before jumping to an unconstrained `full`. On widescreen viewports the default (`wide` = 896px) left large empty margins, and the first three options were nearly indistinguishable.

The body's `PROSE_CLASSES` already sets `max-w-none` (`src/lib/prose-classes.ts`), so the container's `max-w-*` is the true effective width — the options looked similar purely because their values were spaced too closely, not because of a hidden `65ch` prose cap.

## What changed

Re-space to clear, widescreen-friendly steps, default widened to fill large screens:

| Bucket | Before | After | Class |
| --- | --- | --- | --- |
| narrow | 672px | 672px | `max-w-2xl` |
| medium | 768px | 896px | `max-w-4xl` |
| **wide** (default) | **896px** | **1408px** | `max-w-[88rem]` |
| full | unconstrained | unconstrained | `max-w-none` |

- `src/components/ImmersiveReader.tsx` — re-spaced `COLUMN_WIDTH_CLASS`; gave the wider `wide` bucket the same roomier `sm:px-10` padding as `full`.
- `src/components/ImmersiveReadingPrefsPopover.tsx` — updated the decorative preview bars (40/60/80/100) to mirror the now-distinct widths.

The enum values (`narrow | medium | wide | full`) are unchanged, so persisted prefs (`amytis-reader-prefs`) need no migration — existing readers on the default or `wide` get the wider rendering automatically; explicit `narrow`/`medium` choices are preserved.

## Verification

- `bun run lint && bun run test` — green (629 pass, 0 fail).
- Manual: enter immersive mode on a ≥1440px window, confirm the default fills more of the viewport and narrow → medium → wide → full are each clearly distinct (the full 1408px shows best with the sidebar closed or on larger displays). Reload to confirm width persists.