### PR TITLE
fix: serve Vercel build as static export, not Next.js server build

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "framework": "nextjs",
+  "framework": null,
   "buildCommand": "bun run build",
   "installCommand": "bun install --frozen-lockfile",
   "outputDirectory": "out"


### PR DESCRIPTION
## Problem

The red **CI** mark on `main` is the **Vercel deployment** check, not GitHub Actions (the `Build & Test` workflow is green). Vercel's build fails *after* a successful Next.js export with:

```
The file "/vercel/path0/out/routes-manifest.json" couldn't be found.
```

**Root cause:** `vercel.json` pins `"framework": "nextjs"` together with `"outputDirectory": "out"`. The `nextjs` preset runs the `@vercel/next` builder, which expects a `routes-manifest.json` inside the output directory. This project is a static export (`output: "export"` in `next.config.ts`), so `out/` only contains plain HTML + the Pagefind index + optimized images — never a routes manifest. Every production deploy since the settings were pinned has failed (#112 `cccf1b3`, #113 `c9ac5c2`, both `Vercel=failure`).

## Fix

Set `"framework": null`. Vercel then runs `installCommand` → `buildCommand` and serves `outputDirectory` (`out/`) verbatim as a static site — no `@vercel/next` builder, no manifest requirement. This matches the self-contained static-export model the rest of the project already assumes (`docs/deployment.md`, nginx/Caddy configs).

`bun run build` writes the Pagefind index and optimized images into `out/` *after* `next build`; serving `out/` as-is guarantees those artifacts ship — which the rejected alternative (keep `nextjs`, drop `outputDirectory`) would have risked.

## Verification

Vercel deploys only run on the platform. After this lands, confirm the status turns green:

```bash
gh api repos/{owner}/{repo}/commits/main/status \
  --jq '.statuses[] | select(.context=="Vercel") | .state'   # expect: success
```

Then spot-check the deployed site: a content page loads, search returns results, and an optimized image renders.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment configuration to remove the explicit Next.js framework setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->