### PR TITLE
Elegance & robustness: strict-build, a11y, perf, CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  workflow_dispatch:
 
 jobs:
   build-and-test:
@@ -26,8 +27,55 @@ jobs:
       - name: Lint
         run: bun run lint
 
+      - name: Typecheck
+        run: bun run typecheck
+
       - name: Run Tests
         run: bun run test
 
       - name: Build
         run: bun run build:dev
+
+      - name: E2E (serve static export)
+        run: |
+          # Serve the static export and run the bun e2e specs against it.
+          # The specs skip when no server responds, so fail loudly if the
+          # server never comes up — otherwise e2e would be a silent no-op.
+          bunx serve@latest out -l 3000 &
+          SERVER_PID=$!
+          for i in $(seq 1 30); do
+            if curl -sf http://localhost:3000 >/dev/null 2>&1; then break; fi
+            sleep 1
+          done
+          if ! curl -sf http://localhost:3000 >/dev/null 2>&1; then
+            echo "Static server failed to start on :3000" >&2
+            exit 1
+          fi
+          bun run test:e2e
+          STATUS=$?
+          kill "$SERVER_PID" 2>/dev/null || true
+          exit $STATUS
+
+  production-build:
+    name: Production build (full)
+    runs-on: ubuntu-latest
+    # The full production build (image optimization + prod Pagefind path) is
+    # ~1-2 min heavier than build:dev and exercises the export-only paths PRs
+    # don't. Gated to manual runs so it never slows the PR loop — trigger it
+    # from the Actions tab before a release.
+    if: github.event_name == 'workflow_dispatch'
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v1
+        with:
+          bun-version: 1.3.11
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Build (production)
+        run: bun run build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,9 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          # This job only reads the repo; don't leave the token in git config.
+          persist-credentials: false
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v1
@@ -41,7 +44,7 @@ jobs:
           # Serve the static export and run the bun e2e specs against it.
           # The specs skip when no server responds, so fail loudly if the
           # server never comes up — otherwise e2e would be a silent no-op.
-          bunx serve@latest out -l 3000 &
+          bunx serve@14 out -l 3000 &
           SERVER_PID=$!
           for i in $(seq 1 30); do
             if curl -sf http://localhost:3000 >/dev/null 2>&1; then break; fi
@@ -68,6 +71,9 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          # This job only reads the repo; don't leave the token in git config.
+          persist-credentials: false
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v1

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -435,3 +435,18 @@ Shiki code blocks deliberately keep their normal theme.
 default disabled) must stay in sync. Any schema change to one must be mirrored
 in the other. Locale-aware fields use `{ en, zh }` in `site.config.ts` and
 plain strings in the example.
+
+### Config validation
+
+`src/lib/config-schema.ts` holds a Zod `SiteConfigSchema` that validates
+`site.config.ts` at module load — the root layout imports `siteConfig` from
+there (not from `site.config` directly), so a malformed config fails the build
+with a readable `[amytis]` message instead of surfacing as a cryptic runtime
+error in a route (strict-build invariant). The schema accepts both shipped
+shapes: every locale-aware field is `string | Record<string, string>`, so the
+single-locale example and the bilingual repo config both pass. Objects use
+Zod's default semantics (unknown keys ignored), so adding a config field never
+breaks validation — but a renamed/mistyped *required* key is still caught. An
+integration test (`tests/integration/config-schema.test.ts`) parses both
+configs as a drift guard. Mirror any schema change here when you change either
+config file.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -127,13 +127,21 @@ bun run clean                       # removes .next, out, public/posts
 ## Running Tests
 
 ```bash
-bun test                   # Run all tests
+bun run test               # Run all tests (NOT bare `bun test` — that sweeps in Playwright specs and fails)
+bun run typecheck          # Type-check the repo with tsc --noEmit
 bun run test:unit          # Run unit tests
 bun run test:int           # Run integration tests
-bun run test:e2e           # Run end-to-end tests
+bun run test:e2e           # Run end-to-end specs (need the site served at http://localhost:3000)
 bun run test:mobile        # Run Playwright mobile compatibility tests
 bun run validate           # Lint + test + build:dev
 ```
+
+The `test:e2e` specs fetch `http://localhost:3000` and skip when nothing
+responds, so serve a build first — e.g. `bun run build:dev && bunx serve out -l 3000`
+in one terminal, then `bun run test:e2e` in another. CI (`.github/workflows/ci.yml`)
+does this automatically after the build, and fails if the server doesn't come up.
+CI also runs `bun run typecheck`; the full production build (`bun run build`) is a
+manual `workflow_dispatch` job.
 
 ### Mobile Compatibility Tests
 

--- a/package.json
+++ b/package.json
@@ -40,10 +40,11 @@
     "deploy": "bun scripts/deploy.ts",
     "start": "next start",
     "lint": "eslint",
+    "typecheck": "tsc --noEmit",
     "test": "bun test src tests/unit tests/tooling packages/create-amytis/src && bun run test:int",
     "test:unit": "bun test src tests/unit packages/create-amytis/src",
     "test:int": "bun test tests/integration",
-    "test:e2e": "bun test tests/e2e",
+    "test:e2e": "bun test tests/e2e/*.test.ts",
     "test:mobile": "playwright test"
   },
   "dependencies": {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -755,8 +755,10 @@ html.dark .shiki .line.warning {
   *::before,
   *::after {
     animation-duration: 0.01ms !important;
+    animation-delay: -1ms !important; /* skip animation-delay-* so delayed/backwards entrances don't stay hidden */
     animation-iteration-count: 1 !important;
     transition-duration: 0.01ms !important;
+    transition-delay: 0s !important;
     scroll-behavior: auto !important;
   }
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -740,6 +740,27 @@ html.dark .shiki .line.warning {
   }
 }
 
+/* Respect the OS "reduce motion" preference: collapse animations/transitions to
+   near-instant and disable smooth scrolling. This covers the custom entrance
+   animations above (fade-in / slide-up / slide-down + animation-delay-*), the
+   navbar smooth-scroll (html { scroll-behavior: smooth }), and every
+   transition-* utility — without per-element opt-in. The flow-card reveal is
+   already gated behind `prefers-reduced-motion: no-preference`, so it stays off
+   here too. WCAG 2.3.3 (Animation from Interactions). */
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}
+
 @theme inline {
   --color-background: var(--background);
   --color-foreground: var(--foreground);

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,7 +5,10 @@ import Navbar from "@/components/Navbar";
 import Footer from "@/components/Footer";
 import Analytics from "@/components/Analytics";
 import BrowserDetectionBanner from "@/components/BrowserDetectionBanner";
-import { siteConfig } from "../../site.config";
+// Import from config-schema (not site.config directly) so the build-time Zod
+// validation runs: the root layout renders for every page, so a malformed
+// config fails the build with a readable message.
+import { siteConfig } from "@/lib/config-schema";
 import { ThemeProvider } from "@/components/ThemeProvider";
 import { LanguageProvider } from "@/components/LanguageProvider";
 import { getAllSeries, getSeriesData } from '@/lib/content/series';

--- a/src/components/Mermaid.tsx
+++ b/src/components/Mermaid.tsx
@@ -51,50 +51,53 @@ const Mermaid: React.FC<MermaidProps> = ({ chart }) => {
     let cancelled = false;
 
     (async () => {
-      installConsoleWarnFilter();
-
-      // Load the ~600kb mermaid library on demand — only once a diagram
-      // actually mounts client-side — so diagram-free pages never ship it.
-      const mermaid = (await import("mermaid")).default;
-      if (cancelled) return;
-
-      const currentTheme = theme === 'system' ? systemTheme : theme;
-      const isDark = currentTheme === 'dark';
-
-      // Colors matching globals.css
-      const colors = {
-        background: isDark ? "#1c1917" : "#fafaf9", // Stone 900 / 50
-        primary: isDark ? "#1c1917" : "#fafaf9",
-        text: isDark ? "#fafaf9" : "#1c1917", // Stone 50 / 900
-        border: isDark ? "#34d399" : "#059669", // Emerald 400 / 600
-        line: isDark ? "#57534e" : "#a8a29e", // Stone 600 / 400
-      };
-
-      mermaid.initialize({
-        startOnLoad: false,
-        theme: "base",
-        fontFamily: "var(--font-sans)",
-        themeVariables: {
-          background: colors.background,
-          mainBkg: colors.background,
-          primaryColor: colors.primary,
-          primaryTextColor: colors.text,
-          primaryBorderColor: colors.border,
-          lineColor: colors.line,
-          secondaryColor: colors.background,
-          tertiaryColor: colors.background,
-          noteBkgColor: colors.background,
-          noteTextColor: colors.text,
-          noteBorderColor: colors.line,
-        },
-        flowchart: { useMaxWidth: true, htmlLabels: true, curve: 'basis' },
-        sequence: { useMaxWidth: true, showSequenceNumbers: true },
-        er: { useMaxWidth: true },
-        securityLevel: "loose",
-      });
-
-      const id = `mermaid-${Math.random().toString(36).substr(2, 9)}`;
+      // One try/catch over the whole pipeline: a failed dynamic import (chunk
+      // load error) or initialize() must surface the error UI too, not just a
+      // render() failure — otherwise the diagram silently stays blank.
       try {
+        installConsoleWarnFilter();
+
+        // Load the ~600kb mermaid library on demand — only once a diagram
+        // actually mounts client-side — so diagram-free pages never ship it.
+        const mermaid = (await import("mermaid")).default;
+        if (cancelled) return;
+
+        const currentTheme = theme === 'system' ? systemTheme : theme;
+        const isDark = currentTheme === 'dark';
+
+        // Colors matching globals.css
+        const colors = {
+          background: isDark ? "#1c1917" : "#fafaf9", // Stone 900 / 50
+          primary: isDark ? "#1c1917" : "#fafaf9",
+          text: isDark ? "#fafaf9" : "#1c1917", // Stone 50 / 900
+          border: isDark ? "#34d399" : "#059669", // Emerald 400 / 600
+          line: isDark ? "#57534e" : "#a8a29e", // Stone 600 / 400
+        };
+
+        mermaid.initialize({
+          startOnLoad: false,
+          theme: "base",
+          fontFamily: "var(--font-sans)",
+          themeVariables: {
+            background: colors.background,
+            mainBkg: colors.background,
+            primaryColor: colors.primary,
+            primaryTextColor: colors.text,
+            primaryBorderColor: colors.border,
+            lineColor: colors.line,
+            secondaryColor: colors.background,
+            tertiaryColor: colors.background,
+            noteBkgColor: colors.background,
+            noteTextColor: colors.text,
+            noteBorderColor: colors.line,
+          },
+          flowchart: { useMaxWidth: true, htmlLabels: true, curve: 'basis' },
+          sequence: { useMaxWidth: true, showSequenceNumbers: true },
+          er: { useMaxWidth: true },
+          securityLevel: "loose",
+        });
+
+        const id = `mermaid-${Math.random().toString(36).substr(2, 9)}`;
         const { svg } = await mermaid.render(id, chart);
         if (!cancelled) setSvg(svg);
       } catch (error) {

--- a/src/components/Mermaid.tsx
+++ b/src/components/Mermaid.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import React, { useEffect, useRef, useState } from "react";
-import mermaid from "mermaid";
 import { useTheme } from "next-themes";
 
 // Mermaid bundles its own KaTeX and invokes it with `{throwOnError: true,
@@ -47,8 +46,18 @@ const Mermaid: React.FC<MermaidProps> = ({ chart }) => {
   }, []);
 
   useEffect(() => {
-    if (ref.current && chart && mounted) {
+    if (!ref.current || !chart || !mounted) return;
+
+    let cancelled = false;
+
+    (async () => {
       installConsoleWarnFilter();
+
+      // Load the ~600kb mermaid library on demand — only once a diagram
+      // actually mounts client-side — so diagram-free pages never ship it.
+      const mermaid = (await import("mermaid")).default;
+      if (cancelled) return;
+
       const currentTheme = theme === 'system' ? systemTheme : theme;
       const isDark = currentTheme === 'dark';
 
@@ -85,15 +94,19 @@ const Mermaid: React.FC<MermaidProps> = ({ chart }) => {
       });
 
       const id = `mermaid-${Math.random().toString(36).substr(2, 9)}`;
-      mermaid.render(id, chart)
-        .then(({ svg }) => {
-          setSvg(svg);
-        })
-        .catch((error) => {
-          console.error("Mermaid rendering error:", error);
-          setSvg(`<div class="p-4 text-red-500 bg-red-50 border border-red-200 rounded text-sm font-mono">Failed to render diagram. Syntax error?</div>`);
-        });
-    }
+      try {
+        const { svg } = await mermaid.render(id, chart);
+        if (!cancelled) setSvg(svg);
+      } catch (error) {
+        if (cancelled) return;
+        console.error("Mermaid rendering error:", error);
+        setSvg(`<div class="p-4 text-red-500 bg-red-50 border border-red-200 rounded text-sm font-mono">Failed to render diagram. Syntax error?</div>`);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
   }, [chart, theme, systemTheme, mounted]);
 
   return (

--- a/src/lib/config-schema.ts
+++ b/src/lib/config-schema.ts
@@ -1,0 +1,209 @@
+import { z } from 'zod';
+import { siteConfig as rawSiteConfig } from '../../site.config';
+
+/**
+ * Build-time validation of site.config.ts.
+ *
+ * Static export means a malformed config must fail the build with a readable
+ * message, not surface as a cryptic runtime error deep inside a route (e.g. a
+ * non-numeric `pagination.posts` blowing up in route-aliases.ts, or a typo'd
+ * `themeColor`). This schema mirrors the config shape and is parsed at module
+ * load (strict-build invariant).
+ *
+ * It must accept BOTH config shapes Amytis ships:
+ *   - this repo's bilingual config (locale-aware fields are { en, zh } maps)
+ *   - the create-amytis example (i18n disabled, locale-aware fields are plain
+ *     strings)
+ * so every locale-aware field is `string | Record<string, string>`.
+ *
+ * Objects use Zod's default semantics (unknown keys are ignored, not rejected)
+ * so adding a new config field never breaks validation — but a renamed or
+ * mistyped *required* key is still caught, because the expected key goes missing.
+ */
+
+/** A locale-aware field: a plain string (single-locale) or a { locale: value } map. */
+const localeString = z.union([z.string(), z.record(z.string(), z.string())]);
+
+const positiveInt = z.number().int().positive();
+const nonNegativeInt = z.number().int().nonnegative();
+
+const navChildSchema = z.object({
+  name: z.string(),
+  url: z.string(),
+  external: z.boolean().optional(),
+  dividerBefore: z.boolean().optional(),
+});
+
+const navItemSchema = z.object({
+  name: z.string(),
+  url: z.string(),
+  weight: z.number(),
+  external: z.boolean().optional(),
+  dropdown: z.array(z.string()).optional(),
+  children: z.array(navChildSchema).optional(),
+});
+
+const footerLinkSchema = z.object({
+  name: z.string(),
+  url: z.string(),
+  weight: z.number().optional(),
+  external: z.boolean().optional(),
+});
+
+const featureSchema = z.object({
+  enabled: z.boolean(),
+  name: localeString.optional(),
+});
+
+const homepageSectionSchema = z.object({
+  id: z.string(),
+  enabled: z.boolean(),
+  weight: z.number(),
+  maxItems: positiveInt.optional(),
+  order: z.enum(['shuffle', 'date-desc', 'date-asc']).optional(),
+});
+
+const authorSchema = z.object({
+  bio: z.string().optional(),
+  avatar: z.string().optional(),
+  social: z
+    .array(z.object({ image: z.string(), description: z.string() }))
+    .optional(),
+});
+
+export const SiteConfigSchema = z.object({
+  // ── Site identity ──
+  title: localeString,
+  logo: z.object({ src: z.string(), favicon: z.string() }),
+  description: localeString,
+  baseUrl: z.string().min(1),
+  ogImage: z.string(),
+  footerText: localeString,
+
+  // ── i18n ──
+  i18n: z.object({
+    enabled: z.boolean(),
+    defaultLocale: z.string().min(1),
+    locales: z.array(z.string()).min(1),
+  }),
+
+  // ── Navigation & footer ──
+  nav: z.array(navItemSchema),
+  footer: z.object({
+    explore: z.array(footerLinkSchema),
+    connect: z.array(footerLinkSchema),
+    builtWith: z.object({ show: z.boolean(), url: z.string(), text: localeString }),
+    bottomLinks: z.array(z.object({ text: localeString, url: z.string().optional() })),
+  }),
+
+  // ── Social & sharing ──
+  social: z.record(z.string(), z.string()),
+  share: z.object({ enabled: z.boolean(), platforms: z.array(z.string()) }),
+  subscribe: z.object({
+    substack: z.string(),
+    telegram: z.string(),
+    wechat: z.object({ qrCode: z.string(), account: z.string() }),
+    email: z.string(),
+  }),
+
+  // ── Features ──
+  features: z.object({
+    posts: featureSchema,
+    series: featureSchema,
+    books: featureSchema,
+    flow: featureSchema,
+  }),
+
+  // ── Homepage ──
+  hero: z.object({ tagline: localeString, title: localeString, subtitle: localeString }),
+  homepage: z.object({ sections: z.array(homepageSectionSchema) }),
+
+  // ── Content ──
+  pagination: z.object({
+    posts: positiveInt,
+    series: positiveInt,
+    flows: positiveInt,
+    notes: positiveInt,
+  }),
+  posts: z.object({
+    basePath: z.string().min(1),
+    toc: z.boolean(),
+    showFuturePosts: z.boolean(),
+    includeDateInUrl: z.boolean(),
+    authors: z.object({
+      default: z.array(z.string()),
+      showInHeader: z.boolean(),
+      showAuthorCard: z.boolean(),
+    }),
+    excludeFromListing: z.array(z.string()),
+    archive: z.object({ showAuthors: z.boolean() }),
+  }),
+  series: z.object({
+    autoPaths: z.boolean(),
+    customPaths: z.record(z.string(), z.string()),
+  }),
+  flows: z.object({ recentCount: nonNegativeInt }),
+  feed: z.object({
+    maxItems: nonNegativeInt,
+    format: z.enum(['rss', 'atom', 'both']),
+    content: z.enum(['excerpt', 'full']),
+    includeFlows: z.boolean(),
+  }),
+
+  // ── Images & appearance ──
+  images: z.object({ cdnBaseUrl: z.string() }),
+  themeColor: z.enum(['default', 'blue', 'rose', 'amber']),
+  browserCheck: z.object({ updateUrl: z.string() }),
+
+  // ── Analytics ──
+  analytics: z.object({
+    providers: z.array(z.enum(['umami', 'plausible', 'google'])),
+    umami: z.object({ websiteId: z.string(), src: z.string() }),
+    plausible: z.object({ domain: z.string(), src: z.string() }),
+    google: z.object({ measurementId: z.string() }),
+  }),
+
+  // ── Comments ──
+  comments: z.object({
+    provider: z.enum(['giscus', 'disqus']).nullable(),
+    commentable: z.object({
+      posts: z.boolean(),
+      flows: z.boolean(),
+      notes: z.boolean(),
+      bookChapters: z.boolean(),
+      staticPages: z.boolean(),
+    }),
+    giscus: z.object({
+      repo: z.string(),
+      repoId: z.string(),
+      category: z.string(),
+      categoryId: z.string(),
+    }),
+    disqus: z.object({ shortname: z.string() }),
+  }),
+
+  // ── Authors ──
+  authors: z.record(z.string(), authorSchema),
+});
+
+/**
+ * Throws a readable, build-failing error if `config` doesn't satisfy the schema.
+ * Exported so tests can exercise it directly against good and bad fixtures.
+ */
+export function validateSiteConfig(config: unknown): void {
+  const result = SiteConfigSchema.safeParse(config);
+  if (!result.success) {
+    const lines = result.error.issues.map(
+      (i) => `  - ${i.path.join('.') || '(root)'}: ${i.message}`,
+    );
+    throw new Error(`[amytis] Invalid site.config.ts:\n${lines.join('\n')}`);
+  }
+}
+
+// Fail the build immediately (with a readable message) on a malformed config,
+// rather than letting it surface as a cryptic runtime error later. This runs
+// whenever any module imports siteConfig from here.
+validateSiteConfig(rawSiteConfig);
+
+/** The validated site config. Re-exported with its original inferred type. */
+export const siteConfig = rawSiteConfig;

--- a/src/lib/content/books.ts
+++ b/src/lib/content/books.ts
@@ -217,8 +217,11 @@ export function getBookData(slug: string): BookData | null {
 
   const parsed = BookSchema.safeParse(rawData);
   if (!parsed.success) {
-    console.error(`Invalid book frontmatter in ${fullPath}:`, parsed.error.format());
-    return null;
+    // Invalid frontmatter is a build-time error, not a silent skip — consistent
+    // with the missing-chapter throw below (strict-build invariant).
+    throw new Error(
+      `[amytis] Invalid book frontmatter in ${fullPath}: ${JSON.stringify(parsed.error.format())}`
+    );
   }
   const data = parsed.data;
 
@@ -281,8 +284,11 @@ export function getBookChapter(bookSlug: string, chapterSlug: string): BookChapt
 
   const parsed = BookChapterSchema.safeParse(rawData);
   if (!parsed.success) {
-    console.error(`Invalid chapter frontmatter in ${fullPath}:`, parsed.error.format());
-    return null;
+    // A chapter listed in the TOC with broken frontmatter must fail the build,
+    // not silently 404 (strict-build invariant; matches getBookData above).
+    throw new Error(
+      `[amytis] Invalid chapter frontmatter in ${fullPath}: ${JSON.stringify(parsed.error.format())}`
+    );
   }
   const data = parsed.data;
 

--- a/src/lib/content/discovery.ts
+++ b/src/lib/content/discovery.ts
@@ -108,6 +108,16 @@ export function buildSlugRegistry(): Map<string, SlugRegistryEntry> {
       fs.readdirSync(seriesDirectory, { withFileTypes: true }).forEach(entry => {
         if (!entry.isDirectory()) return;
         const slug = entry.name;
+        // Same uniqueness contract as notes: a series slug must not collide
+        // with an existing post / flow / note / alias, or wikilinks become
+        // ambiguous (strict-build invariant).
+        const existing = map.get(slug);
+        if (existing) {
+          throw new Error(
+            `[amytis] Series slug "${slug}" collides with an existing ${existing.type} of the same slug. ` +
+            `Slugs must be unique across posts, flows, notes, and series so wikilinks resolve unambiguously.`
+          );
+        }
         const seriesData = getSeriesData(slug);
         map.set(slug, {
           url: getSeriesUrl(slug),

--- a/src/lib/content/discovery.ts
+++ b/src/lib/content/discovery.ts
@@ -81,16 +81,26 @@ export function buildSlugRegistry(): Map<string, SlugRegistryEntry> {
     );
 
     getAllNotes().forEach(n => {
-      if (map.has(n.slug)) {
-        console.warn(`[slugRegistry] Note slug "${n.slug}" conflicts with an existing entry.`);
+      // Slugs and aliases must be unique across all content so a wikilink
+      // [[target]] resolves unambiguously. A collision is a build-time error,
+      // not a silent overwrite (strict-build invariant).
+      const existing = map.get(n.slug);
+      if (existing) {
+        throw new Error(
+          `[amytis] Note slug "${n.slug}" collides with an existing ${existing.type} of the same slug. ` +
+          `Slugs must be unique across posts, flows, notes, and series so wikilinks resolve unambiguously.`
+        );
       }
       map.set(n.slug, { url: getNoteUrl(n.slug), type: 'note', title: n.title });
       n.aliases.forEach(a => {
-        if (map.has(a)) {
-          console.warn(`[slugRegistry] Note alias "${a}" (→ ${n.slug}) conflicts with existing slug; skipping.`);
-        } else {
-          map.set(a, { url: getNoteUrl(n.slug), type: 'note', title: n.title });
+        const existingAlias = map.get(a);
+        if (existingAlias) {
+          throw new Error(
+            `[amytis] Note alias "${a}" (→ "${n.slug}") collides with an existing ${existingAlias.type}. ` +
+            `Aliases must be unique across all content so wikilinks resolve unambiguously.`
+          );
         }
+        map.set(a, { url: getNoteUrl(n.slug), type: 'note', title: n.title });
       });
     });
 

--- a/src/lib/content/notes.ts
+++ b/src/lib/content/notes.ts
@@ -89,11 +89,9 @@ export function getAllNotes(): NoteData[] {
       if (!item.name.endsWith('.md') && !item.name.endsWith('.mdx')) continue;
       const slug = item.name.replace(/\.mdx?$/, '');
       const fullPath = path.join(notesDirectory, item.name);
-      try {
-        notes.push(parseNoteFile(fullPath, slug));
-      } catch (e) {
-        console.error(`Error parsing note ${fullPath}:`, e);
-      }
+      // Let parse errors propagate — a malformed note must fail the build, not
+      // silently vanish (strict-build invariant; matches getAllFlows).
+      notes.push(parseNoteFile(fullPath, slug));
     }
 
     return notes
@@ -113,13 +111,11 @@ export function getNoteBySlug(slug: string): NoteData | null {
   else if (fs.existsSync(mdPath)) fullPath = mdPath;
   else return null;
 
-  try {
-    const note = parseNoteFile(fullPath, slug);
-    if (process.env.NODE_ENV === 'production' && note.draft) return null;
-    return note;
-  } catch {
-    return null;
-  }
+  // null only when the note doesn't exist; a malformed note throws (strict-build,
+  // matches getFlowBySlug).
+  const note = parseNoteFile(fullPath, slug);
+  if (process.env.NODE_ENV === 'production' && note.draft) return null;
+  return note;
 }
 
 export function getAdjacentNotes(slug: string): { prev: NoteData | null; next: NoteData | null } {

--- a/src/test-utils/render.ts
+++ b/src/test-utils/render.ts
@@ -5,8 +5,14 @@ import { renderToReadableStream } from 'react-dom/server';
  * Renders a React tree (including async server components) to a full HTML string.
  * Use this in tests where the tree contains async components — sync renderers like
  * renderToStaticMarkup throw "A component suspended" for async server components.
+ *
+ * Accepts a Promise too: calling an async server component directly
+ * (`renderAsync(Page(props))`) yields `Promise<ReactElement>`, which
+ * renderToReadableStream awaits just like any other ReactNode.
  */
-export async function renderAsync(element: ReactElement): Promise<string> {
+export async function renderAsync(
+  element: ReactElement | Promise<ReactElement>,
+): Promise<string> {
   const stream = await renderToReadableStream(element);
   await stream.allReady;
   const reader = stream.getReader();

--- a/tests/integration/books.test.ts
+++ b/tests/integration/books.test.ts
@@ -91,4 +91,24 @@ describe("Integration: Books", () => {
       fs.rmSync(bookDir, { recursive: true, force: true });
     }
   });
+
+  test("getBookData throws on invalid frontmatter instead of silently skipping", () => {
+    // Strict-build invariant: a malformed book index must fail the export, not
+    // silently vanish (consistent with the missing-chapter throw above).
+    const slug = "__test-bad-frontmatter__";
+    const bookDir = path.join(process.cwd(), "content", "books", slug);
+    fs.mkdirSync(bookDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(bookDir, "index.mdx"),
+      // `title` is required by BookSchema; omitting it must throw.
+      ["---", "date: 2026-01-01", "chapters: []", "---", "", "Intro", ""].join("\n"),
+      "utf8",
+    );
+
+    try {
+      expect(() => getBookData(slug)).toThrow(/Invalid book frontmatter/);
+    } finally {
+      fs.rmSync(bookDir, { recursive: true, force: true });
+    }
+  });
 });

--- a/tests/integration/config-schema.test.ts
+++ b/tests/integration/config-schema.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test } from "bun:test";
+import { SiteConfigSchema, validateSiteConfig } from "@/lib/config-schema";
+import { siteConfig } from "../../site.config";
+import { siteConfig as exampleConfig } from "../../site.config.example";
+
+// site.config.ts validation (Commit 1.4). The schema must accept both shipped
+// config shapes and reject malformed fields with a readable, build-failing
+// error — the strict-build invariant for author/operator input.
+
+describe("SiteConfigSchema", () => {
+  test("accepts the live bilingual site.config.ts", () => {
+    expect(SiteConfigSchema.safeParse(siteConfig).success).toBe(true);
+    expect(() => validateSiteConfig(siteConfig)).not.toThrow();
+  });
+
+  test("accepts the single-locale create-amytis example config (drift guard)", () => {
+    // Guards against site.config.ts ⇄ site.config.example.ts shape drift: both
+    // must satisfy the same schema even though the example uses plain strings.
+    expect(SiteConfigSchema.safeParse(exampleConfig).success).toBe(true);
+    expect(() => validateSiteConfig(exampleConfig)).not.toThrow();
+  });
+
+  test("rejects a non-numeric pagination value", () => {
+    const bad = structuredClone(siteConfig) as Record<string, unknown>;
+    (bad.pagination as Record<string, unknown>).posts = "five";
+    expect(SiteConfigSchema.safeParse(bad).success).toBe(false);
+    expect(() => validateSiteConfig(bad)).toThrow(/pagination\.posts/);
+  });
+
+  test("rejects a zero/negative pagination value", () => {
+    const bad = structuredClone(siteConfig) as Record<string, unknown>;
+    (bad.pagination as Record<string, unknown>).posts = 0;
+    expect(SiteConfigSchema.safeParse(bad).success).toBe(false);
+  });
+
+  test("rejects an unknown themeColor", () => {
+    const bad = structuredClone(siteConfig) as Record<string, unknown>;
+    bad.themeColor = "purple";
+    expect(SiteConfigSchema.safeParse(bad).success).toBe(false);
+    expect(() => validateSiteConfig(bad)).toThrow(/themeColor/);
+  });
+
+  test("rejects an unknown feed format", () => {
+    const bad = structuredClone(siteConfig) as Record<string, unknown>;
+    (bad.feed as Record<string, unknown>).format = "xml";
+    expect(SiteConfigSchema.safeParse(bad).success).toBe(false);
+  });
+
+  test("rejects a missing required top-level field", () => {
+    const bad = structuredClone(siteConfig) as Record<string, unknown>;
+    delete bad.pagination;
+    expect(SiteConfigSchema.safeParse(bad).success).toBe(false);
+  });
+
+  test("error message is prefixed and lists the offending path", () => {
+    const bad = structuredClone(siteConfig) as Record<string, unknown>;
+    (bad.feed as Record<string, unknown>).content = "summary";
+    expect(() => validateSiteConfig(bad)).toThrow(/\[amytis\] Invalid site\.config\.ts/);
+  });
+});

--- a/tests/integration/config-schema.test.ts
+++ b/tests/integration/config-schema.test.ts
@@ -27,10 +27,12 @@ describe("SiteConfigSchema", () => {
     expect(() => validateSiteConfig(bad)).toThrow(/pagination\.posts/);
   });
 
-  test("rejects a zero/negative pagination value", () => {
-    const bad = structuredClone(siteConfig) as Record<string, unknown>;
-    (bad.pagination as Record<string, unknown>).posts = 0;
-    expect(SiteConfigSchema.safeParse(bad).success).toBe(false);
+  test("rejects a zero or negative pagination value", () => {
+    for (const value of [0, -1]) {
+      const bad = structuredClone(siteConfig) as Record<string, unknown>;
+      (bad.pagination as Record<string, unknown>).posts = value;
+      expect(SiteConfigSchema.safeParse(bad).success).toBe(false);
+    }
   });
 
   test("rejects an unknown themeColor", () => {

--- a/tests/integration/discovery.test.ts
+++ b/tests/integration/discovery.test.ts
@@ -1,3 +1,5 @@
+import fs from 'node:fs';
+import path from 'node:path';
 import { describe, expect, test } from 'bun:test';
 import { getAllTags, buildSlugRegistry, getBacklinks } from '../../src/lib/content/discovery';
 import { getAllPosts } from '../../src/lib/content/posts';
@@ -61,6 +63,29 @@ describe('Integration: discovery (slug registry, backlinks, tags)', () => {
       for (const entry of seriesEntries) {
         expect(entry.url).toMatch(/^\/series\//);
         expect(entry.title.length).toBeGreaterThan(0);
+      }
+    });
+
+    test('throws on a slug/alias collision instead of silently overwriting', () => {
+      // Strict-build invariant: wikilink targets must be unambiguous. Two notes
+      // where one's alias equals the other's slug is a collision and must throw
+      // regardless of filesystem read order (slug-vs-alias collide either way).
+      const notesDir = path.join(process.cwd(), 'content', 'notes');
+      fs.mkdirSync(notesDir, { recursive: true });
+      const noteA = path.join(notesDir, '__test-confl-a__.md');
+      const noteB = path.join(notesDir, '__test-confl-b__.md');
+      fs.writeFileSync(noteA, ['---', 'title: Conflict A', '---', '', 'A', ''].join('\n'), 'utf8');
+      fs.writeFileSync(
+        noteB,
+        ['---', 'title: Conflict B', 'aliases: ["__test-confl-a__"]', '---', '', 'B', ''].join('\n'),
+        'utf8',
+      );
+
+      try {
+        expect(() => buildSlugRegistry()).toThrow(/collides/);
+      } finally {
+        fs.rmSync(noteA, { force: true });
+        fs.rmSync(noteB, { force: true });
       }
     });
   });

--- a/tests/integration/notes.test.ts
+++ b/tests/integration/notes.test.ts
@@ -1,0 +1,30 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, test } from "bun:test";
+import { getAllNotes } from "../../src/lib/content/notes";
+
+describe("Integration: Notes (strict-build)", () => {
+  test("getAllNotes returns an array", () => {
+    expect(Array.isArray(getAllNotes())).toBe(true);
+  });
+
+  test("getAllNotes throws on invalid frontmatter instead of silently skipping", () => {
+    // Strict-build invariant: a malformed note must fail the build, not quietly
+    // disappear from the site (consistent with getAllFlows).
+    const notesDir = path.join(process.cwd(), "content", "notes");
+    fs.mkdirSync(notesDir, { recursive: true });
+    const notePath = path.join(notesDir, "__test-bad-frontmatter__.md");
+    fs.writeFileSync(
+      notePath,
+      // `title` is required by NoteSchema; omitting it must throw.
+      ["---", "tags: [test]", "---", "", "Body without a title.", ""].join("\n"),
+      "utf8",
+    );
+
+    try {
+      expect(() => getAllNotes()).toThrow(/Invalid note frontmatter/);
+    } finally {
+      fs.rmSync(notePath, { force: true });
+    }
+  });
+});


### PR DESCRIPTION
Four focused, independently-reviewable commits making the site more robust and more elegant. Each keeps `lint` green and is bisectable.

## 1. `fix:` strict-build error semantics across the content layer
Enforces the repo's documented *"strict build over silent runtime failure"* principle, which three modules quietly broke:
- **notes.ts** — `getAllNotes` swallowed parse errors (a broken note vanished); now lets them propagate, matching `flows.ts`.
- **discovery.ts** — slug/alias collisions in the wikilink registry were `console.warn` + overwrite (→ wikilinks could resolve to the wrong target); now **throws**.
- **books.ts** — invalid book *and* chapter frontmatter returned `null` while the same code threw on missing chapters; now both throw.
- **New `src/lib/config-schema.ts`** — Zod-validates `site.config.ts` at module load (via the root-layout import), so a malformed config fails the build with a readable `[amytis]` message instead of a cryptic runtime error. Accepts both the bilingual repo config and the single-locale example; an integration test parses both as a drift guard.

## 2. `fix:` respect `prefers-reduced-motion`
Only the flow-card reveal was gated behind a motion query. The entrance animations (fade-in / slide-up / slide-down + delays), navbar smooth-scroll, and all `transition-*` utilities animated regardless of the OS *Reduce motion* setting — a WCAG 2.3.3 miss. Added a global `prefers-reduced-motion: reduce` block.

## 3. `perf:` load the mermaid library on demand
The ~576 KB mermaid library was statically imported and shipped on **every** post/note/flow/chapter page (it's referenced by `MarkdownRenderer`), even diagram-free ones. `MarkdownRenderer` is a Server Component, so `next/dynamic({ ssr: false })` isn't valid there — instead `import('mermaid')` now happens inside the client component's render effect. **Verified:** the mermaid chunk appears in **0** pages' initial load and loads only when a diagram mounts.

## 4. `chore:` add typecheck + e2e gates to CI
CI ran only lint + test + `build:dev`. Added:
- `tsc --noEmit` typecheck (new `typecheck` script). This surfaced a repo-wide type error — `renderAsync` accepted only `ReactElement` while tests pass async-component `Promise<ReactElement>`; widened the param (runtime-neutral).
- An E2E step that serves the static export and runs the bun e2e specs against it, failing if the server never comes up so e2e can't silently skip.
- Fixed `test:e2e` to target `tests/e2e/*.test.ts` so it no longer sweeps in the Playwright `mobile/*.spec.ts` and crashes.
- A manual-only (`workflow_dispatch`) full production-build job for the export paths `build:dev` skips.

## Notable scope decisions
- **Prose line-length cap (considered, dropped):** would have clamped the immersive reader's wide/full width options; body text is already constrained to `max-w-3xl`.
- **Design-token sweep (deferred):** the scattered opacity/size values span ~63 files across 13 near-identical values — a big-bang sweep with embedded visual-design decisions. Tracked as a follow-up.

## Verification
`bun run lint` ✓ · `bun run typecheck` ✓ · `bun run test` (404 + 237 pass, 0 fail) ✓ · clean `bun run build:dev` ✓ · mermaid chunk proven on-demand ✓ · e2e (12 pass) against the served export ✓.

Docs updated: `ARCHITECTURE.md` (config validation seam), `CONTRIBUTING.md` (test commands, CI behavior).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added build-time validation for site configuration with detailed, readable error reporting.
* **Bug Fixes**
  * Strictly fail builds on malformed content (notes/books) and prevent slug/alias collisions from being silently accepted.
  * Improved diagram rendering reliability with a safer fallback message when diagrams can’t be rendered.
  * Added reduced-motion support to disable smooth scrolling and reduce animations/transitions.
* **Tests / CI**
  * Expanded CI coverage with type checking and a more robust static-export end-to-end run.
* **Documentation**
  * Updated testing/build instructions and architecture docs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->