### PR TITLE
fix: stop coupling the build type-check to stale next-dev types

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -39,7 +39,7 @@ bun test
   - `posts/`: Paginated post listing and individual post routes.
   - `flows/`: Stream-style daily notes or micro-blogging (`[year]/[month]/[day]`).
   - `series/`: Series overview and individual series catalog pages with pagination support.
-  - `books/`: Books overview and individual book/chapter pages (`[slug]/[chapter]`).
+  - `books/`: Books overview and individual book/chapter pages (`[slug]/[...chapter]`).
   - `notes/`: Evergreen notes index and individual note pages with backlinks.
   - `archive/`: Timeline-based chronological archive grouped by year and month.
   - `tags/`: Popularity-sorted tag cloud and filtered listings.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -46,7 +46,7 @@ src/app/
   series/[slug]/page/[page]/page.tsx
   books/page.tsx                    # Books index
   books/[slug]/page.tsx             # Book landing
-  books/[slug]/[chapter]/page.tsx   # Book chapter
+  books/[slug]/[...chapter]/page.tsx # Book chapter (catch-all: nested chapter ids)
   flows/page.tsx                    # Flow index (calendar sidebar + full-content card feed)
   flows/page/[page]/page.tsx        # Flow pagination
   flows/[year]/page.tsx

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -27,7 +27,6 @@
     "**/*.ts",
     "**/*.tsx",
     ".next/types/**/*.ts",
-    ".next/dev/types/**/*.ts",
     "**/*.mts"
   ],
   "exclude": ["node_modules"]


### PR DESCRIPTION
## Problem

`bun run build` fails on Windows during the TypeScript type-check step:

```
.next/dev/types/validator.ts:98:39
Type error: Cannot find module '../../../src/app/books/[slug]/[chapter]/page.js'
```

## Root cause

The book-chapter route was renamed `books/[slug]/[chapter]` → `books/[slug]/[...chapter]` (catch-all). The failing file, `.next/dev/types/validator.ts`, is a **stale `next dev` artifact** still importing the pre-rename `[chapter]/page.js`.

- `next build` writes correct route types to `.next/types/` (the local `.next/types/validator.ts` already references `[...chapter]`).
- `next dev` writes a *separate* `.next/dev/types/`. A `next dev` run from **before** the rename left a stale validator there.
- `tsconfig.json` `include` listed **both** `.next/types/**/*.ts` and `.next/dev/types/**/*.ts`, so `next build`'s type-check dragged in the stale dev validator.
- `.next/` is gitignored → per-machine. Only checkouts that ran `next dev` before the rename hit it (Windows here; macOS built clean).

The current official Next.js 16 tsconfig only includes `.next/types/**/*.ts`; the `.next/dev/types/**/*.ts` glob is a legacy create-next-app leftover and is exactly what coupled the production build to dev-server artifacts.

## Fix

- **`tsconfig.json`** — remove the legacy `.next/dev/types/**/*.ts` glob, matching the current official Next.js 16 template. The build and `tsc --noEmit` now only type-check `next build`-generated types, so a stale `next dev` artifact can never break the build again (any OS, any future route rename/delete). Propagates to new `create-amytis` users on the next release. No `typedRoutes` in use and the Next TS plugin still provides editor diagnostics, so there's no dev-workflow downside.
- **`docs/ARCHITECTURE.md`, `GEMINI.md`** — correct two stale references that named the route `[chapter]` instead of the catch-all `[...chapter]`.

## Verification

- `bun run lint` ✓ clean
- `bun run test` ✓ 408 + 239 pass, 0 fail
- **Reproduced and confirmed:** planting a stale `.next/dev/types/validator.ts` with the old import reproduces the exact `TS2307` error when the legacy glob is present, and `tsc --noEmit` ignores it (exit 0) with the glob removed.

**Immediate unblock for an already-affected machine** (the stale `.next/` lingers locally):

```bash
bun run clean   # removes the stale .next/dev/types/
bun run build
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated routing documentation to reflect support for nested book chapter paths.
  * Clarified the chapter route format for the Books section.

* **Chores**
  * Adjusted TypeScript project includes to match the current Next.js type output and add support for MTS files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->