### PR TITLE
fix: address full-codebase review findings (bugs + strict-build gaps)

### DIFF
--- a/scripts/lib/content-file.ts
+++ b/scripts/lib/content-file.ts
@@ -22,6 +22,15 @@ export function extPair(useMd: boolean): { ext: '.md' | '.mdx'; altExt: '.md' | 
   return useMd ? { ext: '.md', altExt: '.mdx' } : { ext: '.mdx', altExt: '.md' };
 }
 
+/**
+ * Escape a string for interpolation inside a double-quoted YAML scalar
+ * (`title: "<here>"`). Backslashes first, then quotes — otherwise a title
+ * containing either writes frontmatter that fails to parse at build time.
+ */
+export function yamlDoubleQuoted(value: string): string {
+  return value.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+}
+
 /** mkdir -p, skipped when the directory already exists. */
 export function ensureDir(dir: string): void {
   if (!fs.existsSync(dir)) {

--- a/scripts/new-from-images.ts
+++ b/scripts/new-from-images.ts
@@ -1,5 +1,6 @@
 import fs from 'fs';
 import path from 'path';
+import { yamlDoubleQuoted } from './lib/content-file';
 
 const args = process.argv.slice(2);
 
@@ -117,7 +118,7 @@ const imageMarkdown = images
   .join('\n\n');
 
 const content = `---
-title: "${postTitle}"
+title: "${yamlDoubleQuoted(postTitle)}"
 date: "${date}"
 excerpt: "A collection of ${images.length} images."
 category: "Gallery"

--- a/scripts/new-from-pdf.ts
+++ b/scripts/new-from-pdf.ts
@@ -1,6 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 import { pdf } from 'pdf-to-img';
+import { yamlDoubleQuoted } from './lib/content-file';
 
 const args = process.argv.slice(2);
 
@@ -81,7 +82,7 @@ const imageMarkdown = images
   .join('\n\n');
 
 const content = `---
-title: "${postTitle}"
+title: "${yamlDoubleQuoted(postTitle)}"
 date: "${date}"
 excerpt: "Content extracted from PDF document."
 category: "Document"

--- a/scripts/new-note.ts
+++ b/scripts/new-note.ts
@@ -1,6 +1,6 @@
 import path from 'path';
 import { slugifyCjk } from './lib/slug';
-import { ensureDir, exitIfExists, extPair, isoDateStamp, writeContentFile } from './lib/content-file';
+import { ensureDir, exitIfExists, extPair, isoDateStamp, writeContentFile, yamlDoubleQuoted } from './lib/content-file';
 
 const args = process.argv.slice(2);
 const titleArg = args.filter(arg => !arg.startsWith('--'))[0];
@@ -26,7 +26,7 @@ exitIfExists(altPath, 'note');
 ensureDir(notesDir);
 
 const content = `---
-title: "${titleArg}"
+title: "${yamlDoubleQuoted(titleArg)}"
 date: "${dateStr}"
 tags: []
 aliases: []

--- a/scripts/new-post.ts
+++ b/scripts/new-post.ts
@@ -1,11 +1,23 @@
 import fs from 'fs';
 import path from 'path';
 import { slugifyAscii } from './lib/slug';
-import { ensureDir, exitIfExists, extPair, isoDateStamp, writeContentFile } from './lib/content-file';
+import { ensureDir, exitIfExists, extPair, isoDateStamp, writeContentFile, yamlDoubleQuoted } from './lib/content-file';
 
 const args = process.argv.slice(2);
 const valuedFlags = ['--template', '--prefix', '--series'];
-const title = args.filter(arg => !arg.startsWith('--') && !valuedFlags.includes(args[args.indexOf(arg) - 1]))[0];
+// First positional arg wins; walk the list and skip each valued flag together
+// with its value. (An indexOf-based lookback misfired whenever the title
+// string equaled a flag's value — `bun run new-weekly weekly` rejected the
+// title because indexOf found the `--prefix weekly` occurrence first.)
+let title = '';
+for (let i = 0; i < args.length; i++) {
+  if (args[i].startsWith('--')) {
+    if (valuedFlags.includes(args[i])) i++;
+    continue;
+  }
+  title = args[i];
+  break;
+}
 const templateArgIndex = args.indexOf('--template');
 const templateName = templateArgIndex > -1 ? args[templateArgIndex + 1] : 'default';
 const prefixArgIndex = args.indexOf('--prefix');
@@ -82,7 +94,12 @@ Write your content here...
 `;
 }
 
-content = content.replace(/{{title}}/g, title).replace(/{{date}}/g, date);
+// Function replacer: with a plain string, $-patterns in the title ($&, $',
+// $1…) are interpreted as replace() back-references and corrupt the output.
+// Templates wrap {{title}} in a double-quoted YAML scalar, so escape for
+// that context (create-amytis guards the same footgun).
+const safeTitle = yamlDoubleQuoted(title);
+content = content.replace(/{{title}}/g, () => safeTitle).replace(/{{date}}/g, date);
 
 exitIfExists(targetPath, 'post');
 

--- a/scripts/new-post.ts
+++ b/scripts/new-post.ts
@@ -97,7 +97,9 @@ Write your content here...
 // Function replacer: with a plain string, $-patterns in the title ($&, $',
 // $1…) are interpreted as replace() back-references and corrupt the output.
 // Templates wrap {{title}} in a double-quoted YAML scalar, so escape for
-// that context (create-amytis guards the same footgun).
+// that context (create-amytis guards the same footgun). NOTE: custom
+// templates must also keep {{title}} inside a double-quoted scalar —
+// yamlDoubleQuoted's backslash escapes are only valid in "…" YAML.
 const safeTitle = yamlDoubleQuoted(title);
 content = content.replace(/{{title}}/g, () => safeTitle).replace(/{{date}}/g, date);
 

--- a/scripts/new-series.ts
+++ b/scripts/new-series.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 import { slugifyGithub } from './lib/slug';
-import { isoDateStamp } from './lib/content-file';
+import { isoDateStamp, yamlDoubleQuoted } from './lib/content-file';
 
 const args = process.argv.slice(2);
 const title = args[0];
@@ -26,8 +26,8 @@ fs.mkdirSync(path.join(seriesDir, 'images'));
 const date = isoDateStamp();
 
 const content = `---
-title: "${title}"
-excerpt: "A description for ${title}."
+title: "${yamlDoubleQuoted(title)}"
+excerpt: "A description for ${yamlDoubleQuoted(title)}."
 date: "${date}"
 coverImage: "https://images.unsplash.com/photo-1618005182384-a83a8bd57fbe?auto=format&fit=crop&w=800&q=80"
 ---

--- a/src/app/series/[slug]/page/[page]/page.tsx
+++ b/src/app/series/[slug]/page/[page]/page.tsx
@@ -8,7 +8,7 @@ import { siteConfig } from '../../../../../../site.config';
 import CoverImage from '@/components/CoverImage';
 import Link from 'next/link';
 import { t, resolveLocale, tWith } from '@/lib/i18n';
-import { getSeriesListUrl } from '@/lib/urls';
+import { getSeriesListUrl, withTrailingSlash } from '@/lib/urls';
 import RedirectPage from '@/components/RedirectPage';
 import { seriesPageParams, resolveSeriesParam } from '@/lib/route-aliases';
 import { paginate } from '@/lib/pagination';
@@ -28,7 +28,7 @@ export async function generateMetadata({ params }: { params: Promise<{ slug: str
     const siteUrl = siteConfig.baseUrl.replace(/\/+$/, '');
     return {
       title: resolution.data.title,
-      alternates: { canonical: `${siteUrl}${getSeriesListUrl()}/${resolution.canonicalSlug}/page/${page}` },
+      alternates: { canonical: withTrailingSlash(`${siteUrl}${getSeriesListUrl()}/${resolution.canonicalSlug}/page/${page}`) },
     };
   }
   const slug = resolution.slug;

--- a/src/app/tags/[tag]/page.tsx
+++ b/src/app/tags/[tag]/page.tsx
@@ -5,6 +5,7 @@ import { notFound } from 'next/navigation';
 import { siteConfig } from '../../../../site.config';
 import { Metadata } from 'next';
 import { resolveLocale } from '@/lib/i18n';
+import { safeDecodeParam, resolveFromParam, withDevEncodedVariants } from '@/lib/route-params';
 import TagPageHeader from '@/components/TagPageHeader';
 import TagSidebar from '@/components/TagSidebar';
 import TagContentTabs from '@/components/TagContentTabs';
@@ -15,24 +16,33 @@ export async function generateStaticParams() {
   if (tagKeys.length === 0) return [{ tag: '_' }];
   // Keys are display-cased; normalize to lowercase for URL slugs and deduplicate.
   const seen = new Set<string>();
-  return tagKeys
-    .map(t => t.toLowerCase())
-    .filter(t => !seen.has(t) && seen.add(t))
-    .map(tag => ({ tag }));
+  return withDevEncodedVariants(
+    tagKeys
+      .map(t => t.toLowerCase())
+      .filter(t => !seen.has(t) && seen.add(t))
+      .map(tag => ({ tag }))
+  );
 }
 
 export const dynamicParams = false;
 
+function resolveTagParam(rawTag: string) {
+  return resolveFromParam(rawTag, (candidate) => {
+    const posts = getPostsByTag(candidate);
+    const flows = getFlowsByTag(candidate);
+    return posts.length + flows.length > 0 ? { tag: candidate, posts, flows } : null;
+  });
+}
+
 export async function generateMetadata({ params }: { params: Promise<{ tag: string }> }): Promise<Metadata> {
   const { tag } = await params;
-  const decodedTag = decodeURIComponent(tag);
-  const posts = getPostsByTag(decodedTag);
-  const flows = getFlowsByTag(decodedTag);
-  const total = posts.length + flows.length;
+  const resolved = resolveTagParam(tag);
+  const displayTag = resolved?.tag ?? safeDecodeParam(tag);
+  const total = resolved ? resolved.posts.length + resolved.flows.length : 0;
 
   return {
-    title: `#${decodedTag} | ${resolveLocale(siteConfig.title)}`,
-    description: `${total} posts tagged with "${decodedTag}".`,
+    title: `#${displayTag} | ${resolveLocale(siteConfig.title)}`,
+    description: `${total} posts tagged with "${displayTag}".`,
   };
 }
 
@@ -42,14 +52,13 @@ export default async function TagPage({
   params: Promise<{ tag: string }>;
 }) {
   const { tag } = await params;
-  const decodedTag = decodeURIComponent(tag);
-  const posts = getPostsByTag(decodedTag);
-  const flows = getFlowsByTag(decodedTag);
+  const resolved = resolveTagParam(tag);
   const allTags = getAllTags();
 
-  if (posts.length === 0 && flows.length === 0) {
+  if (!resolved) {
     notFound();
   }
+  const { tag: decodedTag, posts, flows } = resolved;
 
   return (
     <div className="layout-container">

--- a/src/components/FlowCalendarSidebar.tsx
+++ b/src/components/FlowCalendarSidebar.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useMemo, type ReactNode } from 'react';
+import { useState, useMemo, useSyncExternalStore, type ReactNode } from 'react';
 import Link from 'next/link';
 import { useLanguage } from '@/components/LanguageProvider';
 import { padNumber } from '@/lib/format-utils';
@@ -17,25 +17,55 @@ interface FlowCalendarSidebarProps {
 const WEEKDAYS = ['Su', 'Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa'];
 const MONTH_NAMES = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
 
+// "Today" can't be known at build time, so it's read as an external store:
+// null on the server/hydration pass, the viewer's local date after (the ring
+// appears post-hydration instead of mismatching). Local date parts, not
+// toISOString() — that was UTC and rang the wrong day for off-UTC viewers.
+function subscribeNever() {
+  return () => {};
+}
+function getLocalTodayStr(): string | null {
+  const now = new Date();
+  return `${now.getFullYear()}-${padNumber(now.getMonth() + 1)}-${padNumber(now.getDate())}`;
+}
+function getServerTodayStr(): string | null {
+  return null;
+}
+
 export default function FlowCalendarSidebar({ entryDates, currentDate, tags, selectedTag, onTagSelect, breadcrumb }: FlowCalendarSidebarProps) {
   const { t } = useLanguage();
-  const initialDate = currentDate ? new Date(currentDate + 'T00:00:00') : new Date();
-  const [viewYear, setViewYear] = useState(initialDate.getFullYear());
-  const [viewMonth, setViewMonth] = useState(initialDate.getMonth());
-  const [showBrowse, setShowBrowse] = useState(false);
+  const todayStr = useSyncExternalStore(subscribeNever, getLocalTodayStr, getServerTodayStr);
 
-  const today = new Date();
-  const todayStr = today.toISOString().split('T')[0];
+  // Initial month must be derived from content (currentDate, else the latest
+  // entry) so server HTML and client hydration agree — `new Date()` here
+  // baked the build-time month into the prerender and mismatched once the
+  // viewer's month drifted from it. Only a site with no flows at all falls
+  // through to the viewer's month, which is null during SSR (empty grid,
+  // nothing to mismatch).
+  const latestEntry = entryDates.length > 0 ? entryDates.reduce((a, b) => (a > b ? a : b)) : null;
+  const monthSource = currentDate ?? latestEntry;
+  const [view, setView] = useState<{ year: number; month: number } | null>(() => {
+    if (!monthSource) return null;
+    const d = new Date(monthSource + 'T00:00:00');
+    return { year: d.getFullYear(), month: d.getMonth() };
+  });
+  const effectiveView = view
+    ?? (todayStr ? { year: Number(todayStr.slice(0, 4)), month: Number(todayStr.slice(5, 7)) - 1 } : null);
+  const [showBrowse, setShowBrowse] = useState(false);
 
   const entrySet = useMemo(() => new Set(entryDates), [entryDates]);
 
+  const { year: viewYear, month: viewMonth } = effectiveView ?? { year: 0, month: 0 };
   const firstDay = new Date(viewYear, viewMonth, 1).getDay();
-  const daysInMonth = new Date(viewYear, viewMonth + 1, 0).getDate();
+  // daysInMonth 0 while the view is unresolved → empty day grid.
+  const daysInMonth = effectiveView ? new Date(viewYear, viewMonth + 1, 0).getDate() : 0;
 
-  const monthLabel = new Date(viewYear, viewMonth).toLocaleDateString('en-US', {
-    month: 'long',
-    year: 'numeric',
-  });
+  const monthLabel = effectiveView
+    ? new Date(viewYear, viewMonth).toLocaleDateString('en-US', {
+        month: 'long',
+        year: 'numeric',
+      })
+    : '';
 
   // Build year/month tree from entryDates for browse panel
   const yearMonthTree = useMemo(() => {
@@ -54,21 +84,17 @@ export default function FlowCalendarSidebar({ entryDates, currentDate, tags, sel
   );
 
   function prevMonth() {
-    if (viewMonth === 0) {
-      setViewYear(viewYear - 1);
-      setViewMonth(11);
-    } else {
-      setViewMonth(viewMonth - 1);
-    }
+    if (!effectiveView) return;
+    setView(effectiveView.month === 0
+      ? { year: effectiveView.year - 1, month: 11 }
+      : { year: effectiveView.year, month: effectiveView.month - 1 });
   }
 
   function nextMonth() {
-    if (viewMonth === 11) {
-      setViewYear(viewYear + 1);
-      setViewMonth(0);
-    } else {
-      setViewMonth(viewMonth + 1);
-    }
+    if (!effectiveView) return;
+    setView(effectiveView.month === 11
+      ? { year: effectiveView.year + 1, month: 0 }
+      : { year: effectiveView.year, month: effectiveView.month + 1 });
   }
 
   const days = useMemo(() => {

--- a/src/components/FlowIndexClient.tsx
+++ b/src/components/FlowIndexClient.tsx
@@ -27,10 +27,14 @@ export default function FlowIndexClient({ allFlows, entryDates, tags, feed, brea
   const { t } = useLanguage();
   const [selectedTag, setSelectedTag] = useState<string | null>(null);
 
-  const filteredFlows = useMemo(
-    () => (selectedTag ? allFlows.filter(f => f.tags.includes(selectedTag)) : allFlows),
-    [allFlows, selectedTag],
-  );
+  // Sidebar tag keys are lowercased by getFlowTags() while flow items carry
+  // raw-case tags, so the match must be case-insensitive (same semantics as
+  // getFlowsByTag).
+  const filteredFlows = useMemo(() => {
+    if (!selectedTag) return allFlows;
+    const wanted = selectedTag.toLowerCase();
+    return allFlows.filter(f => f.tags.some(t => t.toLowerCase() === wanted));
+  }, [allFlows, selectedTag]);
 
   function handleTagSelect(tag: string) {
     setSelectedTag(prev => (prev === tag ? null : tag));

--- a/src/layouts/PostLayout.tsx
+++ b/src/layouts/PostLayout.tsx
@@ -43,9 +43,13 @@ export default function PostLayout({ post, relatedPosts, seriesPosts, seriesTitl
   const hasCollections = !!(collectionContexts && collectionContexts.length > 0);
   const showSidebar = showToc || hasSeries || hasCollections;
   const isStaticPage = commentCategory === 'staticPages';
+  // Strip baseUrl's trailing slash in both branches — helpers return
+  // slash-prefixed paths, and a doubled '//' here splits giscus/disqus
+  // comment threads across the two URL forms.
+  const siteUrl = siteConfig.baseUrl.replace(/\/+$/, '');
   const postUrl = isStaticPage
-    ? `${siteConfig.baseUrl.replace(/\/+$/, '')}${getStaticPageUrl(post.slug)}`
-    : `${siteConfig.baseUrl}${getPostUrl(post)}`;
+    ? `${siteUrl}${getStaticPageUrl(post.slug)}`
+    : `${siteUrl}${getPostUrl(post)}`;
   const commentSlug = isStaticPage ? `pages/${post.slug}` : post.slug;
   const bodyRenderer = post.sourceFormat === 'rst'
     ? <RstRenderer content={post.content} html={post.renderedHtml} latex={post.latex} slug={post.imageBaseSlug} slugRegistry={slugRegistry} />

--- a/src/lib/content/books.ts
+++ b/src/lib/content/books.ts
@@ -252,6 +252,22 @@ export function getBookData(slug: string): BookData | null {
     authors = siteConfig.posts?.authors?.default ?? [];
   }
 
+  // In production, drop draft chapters from both the flattened list and the
+  // nested TOC. getBookChapter returns null for them (→ 404), so leaving
+  // them in produced dead prev/next and sidebar links from their published
+  // neighbors. Dev keeps drafts visible, same policy as posts/flows.
+  let toc = data.chapters;
+  let visibleChapters = chapters;
+  if (process.env.NODE_ENV === 'production') {
+    const draftIds = new Set(
+      chapters.filter(ch => isChapterDraft(bookDir, ch.id)).map(ch => ch.id)
+    );
+    if (draftIds.size > 0) {
+      visibleChapters = chapters.filter(ch => !draftIds.has(ch.id));
+      toc = filterTocDrafts(data.chapters, draftIds);
+    }
+  }
+
   return {
     title: data.title,
     slug,
@@ -264,9 +280,47 @@ export function getBookData(slug: string): BookData | null {
     latex: data.latex,
     showChapterExcerpt: data.showChapterExcerpt,
     content: content.trim(),
-    toc: data.chapters,
-    chapters,
+    toc,
+    chapters: visibleChapters,
   };
+}
+
+/**
+ * Light draft probe for TOC filtering: reads only the frontmatter's `draft`
+ * flag. Full schema validation still happens in getBookChapter, so a chapter
+ * with otherwise-broken frontmatter is NOT treated as draft here — it stays
+ * listed and fails the build loudly when rendered (strict-build invariant).
+ */
+function isChapterDraft(bookDir: string, chapterId: string): boolean {
+  const resolved = resolveChapterFilePath(bookDir, chapterId);
+  if (!resolved) return false; // Existence is validated separately above.
+  const { data } = matter(readUtf8File(resolved.path));
+  return data.draft === true;
+}
+
+/** Remove draft chapter refs from the nested TOC; prune emptied parts/sections. */
+function filterTocDrafts(toc: BookTocItem[], draftIds: Set<string>): BookTocItem[] {
+  const filterSectionItems = (
+    items: Array<BookTocSection | BookChapterRef>,
+  ): Array<BookTocSection | BookChapterRef> =>
+    items.flatMap((item): Array<BookTocSection | BookChapterRef> => {
+      if ('section' in item) {
+        const kept = filterSectionItems(item.items);
+        return kept.length > 0 ? [{ ...item, items: kept }] : [];
+      }
+      return draftIds.has(item.id) ? [] : [item];
+    });
+
+  return toc.flatMap((item): BookTocItem[] => {
+    if ('part' in item) {
+      const kept = item.chapters.filter(ch => !draftIds.has(ch.id));
+      return kept.length > 0 ? [{ ...item, chapters: kept }] : [];
+    }
+    if ('section' in item) {
+      return filterSectionItems([item]);
+    }
+    return draftIds.has(item.id) ? [] : [item];
+  });
 }
 
 export function getBookChapter(bookSlug: string, chapterSlug: string): BookChapterData | null {

--- a/src/lib/content/discovery.ts
+++ b/src/lib/content/discovery.ts
@@ -72,13 +72,38 @@ export function buildSlugRegistry(): Map<string, SlugRegistryEntry> {
   return slugRegistryMemo.get(() => {
     const map = new Map<string, SlugRegistryEntry>();
 
-    getAllPosts().forEach(p =>
-      map.set(p.slug, { url: getPostUrl(p), type: 'post', title: p.title })
-    );
+    // Posts throw on canonical-URL collisions, not bare-slug ones: a
+    // duplicate slug is legal when series prefixes (autoPaths/customPaths)
+    // give the posts distinct URLs — the rST toctree fixtures rely on this.
+    // Two posts resolving to the SAME URL is a bug under every config
+    // (e.g. duplicate slugs with series prefixes disabled). Bare-slug
+    // wikilink targets stay last-wins for same-slug series children — a
+    // known ambiguity, [[slug]] has no qualified form to prefer.
+    const postUrlOwners = new Map<string, string>();
+    getAllPosts().forEach(p => {
+      const url = getPostUrl(p);
+      if (postUrlOwners.has(url)) {
+        throw new Error(
+          `[amytis] Two posts resolve to the same URL "${url}". Rename one of them, ` +
+          `or adjust series.autoPaths/customPaths so every post has a unique canonical URL.`
+        );
+      }
+      postUrlOwners.set(url, p.slug);
+      map.set(p.slug, { url, type: 'post', title: p.title });
+    });
 
-    getAllFlows().forEach(f =>
-      map.set(f.slug, { url: getFlowUrl(f.slug), type: 'flow', title: f.title })
-    );
+    getAllFlows().forEach(f => {
+      const existing = map.get(f.slug);
+      if (existing) {
+        // Reachable via a day with both DD.md and DD/index.md — the walk
+        // yields two flows with the same date slug.
+        throw new Error(
+          `[amytis] Flow slug "${f.slug}" collides with an existing ${existing.type} of the same slug. ` +
+          `Slugs must be unique across posts, flows, notes, and series so wikilinks resolve unambiguously.`
+        );
+      }
+      map.set(f.slug, { url: getFlowUrl(f.slug), type: 'flow', title: f.title });
+    });
 
     getAllNotes().forEach(n => {
       // Slugs and aliases must be unique across all content so a wikilink

--- a/src/lib/content/posts.ts
+++ b/src/lib/content/posts.ts
@@ -22,10 +22,18 @@ import { parseMarkdownFile, parseRstPostEntries, type RstPostEntry } from './par
  * top-level files in content/ with optional locale variants.
  */
 
+const allPostsUnfilteredMemo = createMemo<PostData[]>();
 const allPostsMemo = createMemo<PostData[]>();
 
-export function getAllPosts(): PostData[] {
-  return allPostsMemo.get(() => {
+/**
+ * Every post parsed from the content tree, including drafts, future-dated
+ * posts, and static pages — the pre-publication-filter view. Content-layer
+ * internal: it lets validation distinguish "slug doesn't exist at all" (a
+ * build error) from "slug exists but is unpublished here" (a silent skip).
+ * Routes and components must keep using getAllPosts().
+ */
+export function getAllPostsIncludingUnpublished(): PostData[] {
+  return allPostsUnfilteredMemo.get(() => {
     const allPostsData: PostData[] = [];
     const pendingRstPosts: RstPostEntry[] = [];
 
@@ -88,7 +96,13 @@ export function getAllPosts(): PostData[] {
 
     allPostsData.push(...parseRstPostEntries(pendingRstPosts));
 
-    return allPostsData
+    return allPostsData;
+  });
+}
+
+export function getAllPosts(): PostData[] {
+  return allPostsMemo.get(() => {
+    return getAllPostsIncludingUnpublished()
       .filter(post => {
         if (post.category === 'Page') return false;
 

--- a/src/lib/content/series.ts
+++ b/src/lib/content/series.ts
@@ -5,7 +5,7 @@ import { seriesDirectory } from './io';
 import { createMemo, createKeyedMemo } from './cache';
 import { resolveSeriesIndexInfo, getSeriesAuthors } from './series-metadata';
 import { parseMarkdownFile, parseRstFile } from './parse';
-import { getAllPosts, getPostBySlug } from './posts';
+import { getAllPosts, getAllPostsIncludingUnpublished, getPostBySlug } from './posts';
 
 /**
  * Series and collection queries. Collections live here, not in their own
@@ -35,10 +35,20 @@ export function getSeriesPosts(seriesName: string): PostData[] {
     const seriesData = getSeriesData(seriesName);
 
     if (seriesData?.posts && seriesData.posts.length > 0) {
-      // Manual Selection: fetch by slug
-      return seriesData.posts
-        .map(slug => getPostBySlug(slug))
-        .filter((p): p is PostData => p !== null);
+      // Manual Selection: fetch by slug. A slug that matches nothing in the
+      // content tree is a build error (strict-build invariant — books throw
+      // on missing chapters the same way); a post that exists but is
+      // unpublished here (draft in production, future-dated) is skipped
+      // silently like everywhere else.
+      return seriesData.posts.flatMap(slug => {
+        const post = getPostBySlug(slug);
+        if (post) return [post];
+        if (getAllPostsIncludingUnpublished().some(p => p.slug === slug)) return [];
+        throw new Error(
+          `[amytis] Series "${seriesName}" lists post "${slug}" in its manual order, ` +
+          `but no post with that slug exists. Fix or remove the slug in the series index frontmatter.`
+        );
+      });
     }
 
     // Automatic: posts with series field matching this series
@@ -169,8 +179,18 @@ export function getCollectionPosts(collectionSlug: string): PostData[] {
         const post = item.post.includes('/')
           ? postIndex.get(item.post)
           : getPostBySlug(item.post);
+        if (post) return [post];
 
-        return post ? [post] : [];
+        // Same contract as manual series order above: unknown reference →
+        // build error; existing-but-unpublished → silent skip.
+        const existsUnpublished = getAllPostsIncludingUnpublished().some(p =>
+          item.post.includes('/') ? getCollectionKey(p) === item.post : p.slug === item.post
+        );
+        if (existsUnpublished) return [];
+        throw new Error(
+          `[amytis] Collection "${collectionSlug}" lists item "${item.post}", ` +
+          `but no post matches it. Fix or remove the item in the collection index frontmatter.`
+        );
       })
       .filter(post => {
         const key = getCollectionKey(post);

--- a/src/lib/feed-utils.ts
+++ b/src/lib/feed-utils.ts
@@ -32,6 +32,38 @@ function markdownToHtml(markdown: string): string {
   return String(result);
 }
 
+/**
+ * Feed readers resolve nothing relative: rewrite relative and site-relative
+ * src/href against the item's absolute page URL (which ends in '/', so
+ * `images/x.png` resolves exactly as it does on the trailing-slash page).
+ */
+function absolutizeHtmlUrls(html: string, pageUrl: string): string {
+  return html.replace(/(src|href)="([^"]*)"/g, (match, attr: string, url: string) => {
+    if (url === '' || /^(?:[a-z][a-z0-9+.-]*:|\/\/|#)/i.test(url)) return match;
+    try {
+      return `${attr}="${new URL(url, pageUrl).toString()}"`;
+    } catch {
+      return match;
+    }
+  });
+}
+
+/**
+ * Item HTML for content:encoded / Atom <content>. rST posts carry their real
+ * HTML in renderedHtml — running the rST source through a Markdown parser
+ * mangles directives into literal text — and Markdown posts go through the
+ * plain GFM pipeline.
+ */
+function itemContentHtml(
+  post: { content: string; renderedHtml?: string; sourceFormat?: 'markdown' | 'rst' },
+  pageUrl: string,
+): string {
+  const html = post.sourceFormat === 'rst' && post.renderedHtml
+    ? post.renderedHtml
+    : markdownToHtml(post.content);
+  return absolutizeHtmlUrls(html, pageUrl);
+}
+
 export type FeedType = 'main' | 'posts' | 'flows' | 'all';
 
 /**
@@ -47,24 +79,30 @@ export function getFeedItems(feedType: FeedType = 'main', includeFullContent: bo
 
   let items: FeedItem[] = [];
 
-  const getPostItems = () => getAllPosts().map((post) => ({
-    title: post.title,
-    url: withTrailingSlash(`${baseUrl}${getPostUrl(post)}`),
-    date: new Date(post.date),
-    excerpt: post.excerpt,
-    content: includeFullContent ? markdownToHtml(post.content) : '',
-    tags: post.tags || [],
-    authors: post.authors,
-  }));
+  const getPostItems = () => getAllPosts().map((post) => {
+    const url = withTrailingSlash(`${baseUrl}${getPostUrl(post)}`);
+    return {
+      title: post.title,
+      url,
+      date: new Date(post.date),
+      excerpt: post.excerpt,
+      content: includeFullContent ? itemContentHtml(post, url) : '',
+      tags: post.tags || [],
+      authors: post.authors,
+    };
+  });
 
-  const getFlowItems = () => getAllFlows().map((flow) => ({
-    title: flow.title,
-    url: withTrailingSlash(`${baseUrl}${getFlowUrl(flow.slug)}`),
-    date: new Date(flow.date),
-    excerpt: flow.excerpt,
-    content: includeFullContent ? markdownToHtml(flow.content) : '',
-    tags: flow.tags || [],
-  }));
+  const getFlowItems = () => getAllFlows().map((flow) => {
+    const url = withTrailingSlash(`${baseUrl}${getFlowUrl(flow.slug)}`);
+    return {
+      title: flow.title,
+      url,
+      date: new Date(flow.date),
+      excerpt: flow.excerpt,
+      content: includeFullContent ? itemContentHtml(flow, url) : '',
+      tags: flow.tags || [],
+    };
+  });
 
   if (feedType === 'posts') {
     items = getPostItems();

--- a/src/lib/remark-wikilinks.test.ts
+++ b/src/lib/remark-wikilinks.test.ts
@@ -83,4 +83,22 @@ describe('remarkWikilinks', () => {
     expect((node as { type: string; value: string }).value).toContain('wikilink--post');
     expect((node as { type: string; value: string }).value).toContain('>Another Post</a>');
   });
+
+  test('escapes HTML in display labels (raw html node, rehypeRaw downstream)', () => {
+    const tree = makeTree('[[my-note|<img src=x onerror=alert(1)>]]');
+    remarkWikilinks({ slugRegistry: registry })(tree);
+    const [node] = getChildren(tree);
+    const value = (node as { type: string; value: string }).value;
+    expect(value).not.toContain('<img');
+    expect(value).toContain('&lt;img src=x onerror=alert(1)&gt;');
+  });
+
+  test('escapes quotes in broken-link slug so the title attribute cannot be escaped', () => {
+    const tree = makeTree('[[bad" onmouseover="alert(1)]]');
+    remarkWikilinks({ slugRegistry: registry })(tree);
+    const [node] = getChildren(tree);
+    const value = (node as { type: string; value: string }).value;
+    expect(value).not.toContain('onmouseover="alert');
+    expect(value).toContain('&quot;');
+  });
 });

--- a/src/lib/remark-wikilinks.ts
+++ b/src/lib/remark-wikilinks.ts
@@ -6,6 +6,17 @@ interface WikilinksOptions {
   slugRegistry: Map<string, SlugRegistryEntry>;
 }
 
+// The nodes below are emitted as raw `html` and pass through rehypeRaw
+// unescaped, so author-controlled text (slug, display) must be entity-escaped
+// or `[[x|<img onerror=…>]]` injects markup into the rendered page.
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
 export default function remarkWikilinks({ slugRegistry }: WikilinksOptions) {
   return (tree: Root) => {
     visit(tree, 'text', (node: Text, index: number | undefined, parent: Parent | undefined) => {
@@ -33,12 +44,12 @@ export default function remarkWikilinks({ slugRegistry }: WikilinksOptions) {
         if (entry) {
           newNodes.push({
             type: 'html',
-            value: `<a href="${entry.url}" class="wikilink wikilink--resolved wikilink--${entry.type}">${display}</a>`,
+            value: `<a href="${escapeHtml(entry.url)}" class="wikilink wikilink--resolved wikilink--${entry.type}">${escapeHtml(display)}</a>`,
           });
         } else {
           newNodes.push({
             type: 'html',
-            value: `<span class="wikilink wikilink--broken" title="[[${slug}]] not found">${display}</span>`,
+            value: `<span class="wikilink wikilink--broken" title="[[${escapeHtml(slug)}]] not found">${escapeHtml(display)}</span>`,
           });
         }
 

--- a/src/lib/rst-renderer.ts
+++ b/src/lib/rst-renderer.ts
@@ -103,7 +103,7 @@ function ensureSpawnOutputString(output: string | NodeJS.ArrayBufferView | null 
 }
 
 function getRstRendererSourceHash(filePath: string): string {
-  return createHash('sha1').update(fs.readFileSync(filePath)).digest('hex');
+  return createHash('sha1').update(fs.readFileSync(/* turbopackIgnore: true */ filePath)).digest('hex');
 }
 
 // Hash of the renderer SCRIPT itself. Changing scripts/render-rst.py changes the
@@ -172,7 +172,7 @@ function loadRenderedRstDocumentFromDiskCache(filePath: string, imageBaseSlug: s
   if (!fs.existsSync(cachePath)) return null;
 
   try {
-    const raw = fs.readFileSync(cachePath, 'utf8');
+    const raw = fs.readFileSync(/* turbopackIgnore: true */ cachePath, 'utf8');
     const parsed = JSON.parse(raw) as Partial<RstRendererDiskCacheEntry>;
     if (
       parsed.version !== RST_RENDERER_DISK_CACHE_VERSION ||

--- a/src/lib/text-metrics.test.ts
+++ b/src/lib/text-metrics.test.ts
@@ -196,6 +196,13 @@ describe("text metrics", () => {
       expect(headings.map((h) => h.text)).toEqual(["Real", "Also Real"]);
     });
 
+    test("ignores heading-like lines inside tilde fences too", () => {
+      const content = ["~~~bash", "## not a heading", "~~~", "", "## Setup"].join("\n");
+      const headings = getHeadings(content);
+      expect(headings).toHaveLength(1);
+      expect(headings[0]).toEqual({ id: "setup", text: "Setup", level: 2 });
+    });
+
     test("fenced duplicates do not burn slug dedup slots", () => {
       // A `## Setup` inside a fence must not claim the "setup" slug — the
       // rendered HTML gives the real heading id="setup", and the TOC must match.

--- a/src/lib/text-metrics.test.ts
+++ b/src/lib/text-metrics.test.ts
@@ -35,10 +35,14 @@ describe("text metrics", () => {
 
     test("should strip links but keep text", () => {
       const text = "Check [this link](https://example.com)";
-      // generateExcerpt strips bold/italic markers and backticks but
-      // does not fully strip markdown link syntax
+      expect(generateExcerpt(text)).toBe("Check this link");
+    });
+
+    test("should not leak URLs into the excerpt", () => {
+      const text = "See [the docs](https://example.com/very/long/path) for details";
       const result = generateExcerpt(text);
-      expect(result).toContain("this link");
+      expect(result).toBe("See the docs for details");
+      expect(result).not.toContain("https://");
     });
   });
 
@@ -184,6 +188,21 @@ describe("text metrics", () => {
       const content = "Just plain text with no headings at all.";
       const headings = getHeadings(content);
       expect(headings).toEqual([]);
+    });
+
+    test("ignores heading-like lines inside fenced code blocks", () => {
+      const content = ["## Real", "", "```bash", "## not a heading", "```", "", "## Also Real"].join("\n");
+      const headings = getHeadings(content);
+      expect(headings.map((h) => h.text)).toEqual(["Real", "Also Real"]);
+    });
+
+    test("fenced duplicates do not burn slug dedup slots", () => {
+      // A `## Setup` inside a fence must not claim the "setup" slug — the
+      // rendered HTML gives the real heading id="setup", and the TOC must match.
+      const content = ["```md", "## Setup", "```", "", "## Setup"].join("\n");
+      const headings = getHeadings(content);
+      expect(headings).toHaveLength(1);
+      expect(headings[0].id).toBe("setup");
     });
   });
 

--- a/src/lib/text-metrics.ts
+++ b/src/lib/text-metrics.ts
@@ -92,8 +92,8 @@ export function generateExcerpt(content: string): string {
   let plain = content.replace(/^#+\s+/gm, '');
   plain = plain.replace(/```[\s\S]*?```/g, '');
   plain = plain.replace(/!\[[^\]]*\]\([^)]+\)/g, '');
-  plain = plain.replace(/\*\[([^\]]+)\*\]\([^)]+\)/g, '$1');
-  plain = plain.replace(/(\$\*\*|__|\*|_)/g, '');
+  plain = plain.replace(/\[([^\]]+)\]\([^)]+\)/g, '$1');
+  plain = plain.replace(/(\*\*|__|\*|_)/g, '');
   plain = plain.replace(/`([^`]+)`/g, '$1');
   plain = plain.replace(/^>\s+/gm, '');
   plain = plain.replace(/\s+/g, ' ').trim();
@@ -110,7 +110,13 @@ export function getHeadings(content: string): Heading[] {
   const slugger = new GithubSlugger();
   let match;
 
-  while ((match = regex.exec(content)) !== null) {
+  // Strip fenced code blocks first: a `## foo` line inside a fence is not a
+  // heading in the rendered HTML, so harvesting it would emit a dead TOC
+  // anchor AND burn the slugger's dedup slot, desyncing every later
+  // duplicate-text heading id from the one rehype-slug assigns.
+  const withoutFences = content.replace(/```[\s\S]*?```/g, '');
+
+  while ((match = regex.exec(withoutFences)) !== null) {
     const level = match[1].length;
     const text = match[2].trim();
     const id = slugger.slug(text);

--- a/src/lib/text-metrics.ts
+++ b/src/lib/text-metrics.ts
@@ -24,13 +24,18 @@ const HAN_CHAR_RE = /[㐀-䶿一-鿿豈-﫿]/g;
 // Latin word: alphanumeric runs allowing apostrophes/hyphens between runs.
 const LATIN_WORD_RE = /[A-Za-z0-9]+(?:['’-][A-Za-z0-9]+)*/g;
 
+// Fenced code blocks in BOTH CommonMark fence styles (``` and ~~~). A fence's
+// body is not prose: it must not count as words, leak into excerpts, or
+// contribute TOC headings. Only used with .replace(), which resets lastIndex.
+const FENCED_CODE_BLOCK_RE = /```[\s\S]*?```|~~~[\s\S]*?~~~/g;
+
 // Shared text-stripping + tokenization used by both `calculateReadingMinutes`
 // and `calculateWordCount`. Both metrics need the same view of "what counts
 // as a word," so funnel them through a single source of truth.
 function countContentTokens(content: string): { latinWords: number; hanChars: number } {
   const text = content
     .replace(/<\/?[^>]+(>|$)/g, "")
-    .replace(/```[\s\S]*?```/g, "")
+    .replace(FENCED_CODE_BLOCK_RE, "")
     .replace(/`[^`]*`/g, "")
     .replace(/!\[[^\]]*\]\([^)]+\)/g, "")
     .replace(/\[([^\]]+)\]\([^)]+\)/g, "$1")
@@ -90,7 +95,7 @@ export function calculateWordCountFromText(text: string): number {
 
 export function generateExcerpt(content: string): string {
   let plain = content.replace(/^#+\s+/gm, '');
-  plain = plain.replace(/```[\s\S]*?```/g, '');
+  plain = plain.replace(FENCED_CODE_BLOCK_RE, '');
   plain = plain.replace(/!\[[^\]]*\]\([^)]+\)/g, '');
   plain = plain.replace(/\[([^\]]+)\]\([^)]+\)/g, '$1');
   plain = plain.replace(/(\*\*|__|\*|_)/g, '');
@@ -114,7 +119,7 @@ export function getHeadings(content: string): Heading[] {
   // heading in the rendered HTML, so harvesting it would emit a dead TOC
   // anchor AND burn the slugger's dedup slot, desyncing every later
   // duplicate-text heading id from the one rehype-slug assigns.
-  const withoutFences = content.replace(/```[\s\S]*?```/g, '');
+  const withoutFences = content.replace(FENCED_CODE_BLOCK_RE, '');
 
   while ((match = regex.exec(withoutFences)) !== null) {
     const level = match[1].length;

--- a/tests/integration/books.test.ts
+++ b/tests/integration/books.test.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { describe, expect, test } from "bun:test";
-import { getAllBooks, getBookData, getFeaturedBooks } from '../../src/lib/content/books';
+import { getAllBooks, getBookData, getBookChapter, getFeaturedBooks } from '../../src/lib/content/books';
 import { setEnvVar, restoreEnvVar } from "../helpers/env";
 
 describe("Integration: Books", () => {
@@ -108,6 +108,60 @@ describe("Integration: Books", () => {
     try {
       expect(() => getBookData(slug)).toThrow(/Invalid book frontmatter/);
     } finally {
+      fs.rmSync(bookDir, { recursive: true, force: true });
+    }
+  });
+
+  test("draft chapters are dropped from chapters/toc/prev-next in production", () => {
+    // getBookChapter 404s a draft chapter in production, so the book's
+    // chapter list and TOC must not advertise it — published neighbors would
+    // otherwise render dead prev/next and sidebar links.
+    const slug = "__test-draft-chapter__";
+    const bookDir = path.join(process.cwd(), "content", "books", slug);
+    fs.mkdirSync(bookDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(bookDir, "index.mdx"),
+      [
+        "---",
+        'title: "Draft Chapter Book"',
+        "date: 2026-01-01",
+        "chapters:",
+        '  - title: "One"',
+        "    id: ch1",
+        '  - title: "Two (draft)"',
+        "    id: ch2",
+        '  - title: "Three"',
+        "    id: ch3",
+        "---",
+        "",
+        "Intro",
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+    const chapterBody = (draft: boolean) =>
+      ["---", `draft: ${draft}`, "---", "", "Body.", ""].join("\n");
+    fs.writeFileSync(path.join(bookDir, "ch1.md"), chapterBody(false), "utf8");
+    fs.writeFileSync(path.join(bookDir, "ch2.md"), chapterBody(true), "utf8");
+    fs.writeFileSync(path.join(bookDir, "ch3.md"), chapterBody(false), "utf8");
+
+    const prev = process.env.NODE_ENV;
+    try {
+      // Dev: drafts stay visible (same policy as posts/flows).
+      const devBook = getBookData(slug);
+      expect(devBook!.chapters.map((c) => c.id)).toEqual(["ch1", "ch2", "ch3"]);
+
+      setEnvVar("NODE_ENV", "production");
+      const prodBook = getBookData(slug);
+      expect(prodBook!.chapters.map((c) => c.id)).toEqual(["ch1", "ch3"]);
+      expect(JSON.stringify(prodBook!.toc)).not.toContain("ch2");
+
+      const ch3 = getBookChapter(slug, "ch3");
+      expect(ch3!.prevChapter!.id).toBe("ch1");
+      const ch1 = getBookChapter(slug, "ch1");
+      expect(ch1!.nextChapter!.id).toBe("ch3");
+    } finally {
+      restoreEnvVar("NODE_ENV", prev);
       fs.rmSync(bookDir, { recursive: true, force: true });
     }
   });

--- a/tests/integration/discovery.test.ts
+++ b/tests/integration/discovery.test.ts
@@ -88,6 +88,25 @@ describe('Integration: discovery (slug registry, backlinks, tags)', () => {
         fs.rmSync(noteB, { force: true });
       }
     });
+
+    test('throws on a duplicate flow slug (DD.md next to DD/index.md)', () => {
+      // Both forms of the same day resolve to one YYYY/MM/DD slug; the walk
+      // yields two flows and the registry must refuse the ambiguity instead
+      // of silently keeping the last one.
+      const dayDir = path.join(process.cwd(), 'content', 'flows', '1999', '01');
+      fs.mkdirSync(path.join(dayDir, '01'), { recursive: true });
+      const flowFile = path.join(dayDir, '01.md');
+      const flowIndex = path.join(dayDir, '01', 'index.md');
+      const body = ['---', 'title: Dup Flow', '---', '', 'x', ''].join('\n');
+      fs.writeFileSync(flowFile, body, 'utf8');
+      fs.writeFileSync(flowIndex, body, 'utf8');
+
+      try {
+        expect(() => buildSlugRegistry()).toThrow(/Flow slug "1999\/01\/01" collides/);
+      } finally {
+        fs.rmSync(path.join(process.cwd(), 'content', 'flows', '1999'), { recursive: true, force: true });
+      }
+    });
   });
 
   describe('getBacklinks', () => {

--- a/tests/integration/feed-utils.test.ts
+++ b/tests/integration/feed-utils.test.ts
@@ -148,6 +148,31 @@ describe("Integration: Feed Utils", () => {
     });
   });
 
+  test("full-content items carry no relative src/href (feed readers resolve nothing)", () => {
+    const items = getFeedItems("all", true);
+    items.forEach((item) => {
+      for (const [, , url] of item.content.matchAll(/(src|href)="([^"]*)"/g)) {
+        if (url === "" || url.startsWith("#")) continue;
+        expect(url).toMatch(/^[a-z][a-z0-9+.-]*:|^\/\//i);
+      }
+    });
+  });
+
+  // renderedHtml exists only when the Python docutils renderer ran; the JS
+  // fallback leaves it unset (same environment gate as the rst-parity tests).
+  const rstPostWithHtml = getAllPosts().find((p) => p.sourceFormat === "rst" && p.renderedHtml);
+  const rstFeedTest = rstPostWithHtml ? test : test.skip;
+
+  rstFeedTest("rST posts use their rendered HTML in full-content feeds", () => {
+    // Running rST source through the Markdown pipeline mangles directives
+    // into literal text; renderedHtml is the real document.
+    const url = withTrailingSlash(siteConfig.baseUrl.replace(/\/+$/, "") + getPostUrl(rstPostWithHtml!));
+    const item = getFeedItems("posts", true).find((i) => i.url === url);
+    expect(item).toBeDefined();
+    expect(item!.content).not.toContain(".. code-block::");
+    expect(item!.content).not.toMatch(/^\.\. /m);
+  });
+
   test("feed items with authors have a non-empty authors array", () => {
     const items = getFeedItems();
     items.forEach((item) => {

--- a/tests/integration/series-strict-resolution.test.ts
+++ b/tests/integration/series-strict-resolution.test.ts
@@ -1,0 +1,81 @@
+import { describe, test, expect } from 'bun:test';
+import fs from 'fs';
+import path from 'path';
+import { getSeriesPosts, getCollectionPosts } from '@/lib/content/series';
+
+/**
+ * Strict-build invariant: a manual series order or collection item that
+ * references a slug matching nothing in the content tree must throw at
+ * build time, not silently drop the post (mirrors books' missing-chapter
+ * throw). Posts that exist but are unpublished (draft in production,
+ * future-dated) are still skipped silently — that path is exercised by
+ * the production build, not here (dev keeps drafts visible).
+ *
+ * Fixtures use fresh series slugs so the keyed memos compute them fresh;
+ * cleanup runs in finally so an interrupted run leaves no state behind.
+ */
+
+const seriesRoot = path.join(process.cwd(), 'content', 'series');
+
+function writeSeriesFixture(slug: string, frontmatterLines: string[]): string {
+  const dir = path.join(seriesRoot, slug);
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(
+    path.join(dir, 'index.md'),
+    ['---', ...frontmatterLines, '---', '', 'Test fixture body.', ''].join('\n'),
+    'utf8',
+  );
+  return dir;
+}
+
+describe('strict series/collection slug resolution', () => {
+  test('manual series order throws on a slug that matches no post', () => {
+    const slug = '__test-manual-missing__';
+    const dir = writeSeriesFixture(slug, [
+      'title: "Manual Missing Fixture"',
+      'date: "2026-01-01"',
+      'sort: "manual"',
+      'posts: ["__test-no-such-post__"]',
+    ]);
+
+    try {
+      expect(() => getSeriesPosts(slug)).toThrow(/lists post "__test-no-such-post__"/);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('collection throws on an item that matches no post', () => {
+    const slug = '__test-collection-missing__';
+    const dir = writeSeriesFixture(slug, [
+      'type: collection',
+      'title: "Collection Missing Fixture"',
+      'date: "2026-01-01"',
+      'items:',
+      '  - post: __test-no-such-post__',
+    ]);
+
+    try {
+      expect(() => getCollectionPosts(slug)).toThrow(/lists item "__test-no-such-post__"/);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('collection throws on a qualified series/slug item that matches no post', () => {
+    const slug = '__test-collection-qualified__';
+    const dir = writeSeriesFixture(slug, [
+      'type: collection',
+      'title: "Collection Qualified Fixture"',
+      'date: "2026-01-01"',
+      'items:',
+      '  - post: no-such-series/__test-no-such-post__',
+    ]);
+
+    try {
+      expect(() => getCollectionPosts(slug)).toThrow(/lists item "no-such-series\/__test-no-such-post__"/);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/tooling/new-post.test.ts
+++ b/tests/tooling/new-post.test.ts
@@ -2,6 +2,8 @@ import { describe, test, expect, afterAll } from "bun:test";
 import { spawnSync } from "bun";
 import fs from "fs";
 import path from "path";
+import matter from "gray-matter";
+import { slugifyAscii } from "../../scripts/lib/slug";
 
 const SCRIPT_PATH = "scripts/new-post.ts";
 const CONTENT_DIR = "content/posts";
@@ -67,6 +69,46 @@ describe("Tooling: New Post Script", () => {
     const second = spawnSync(["bun", SCRIPT_PATH, title]);
     expect(second.exitCode).toBe(1);
     expect(second.stderr.toString()).toContain("Error: Post already exists at");
+  });
+
+  test("accepts a title equal to a valued flag's value", () => {
+    // Regression: indexOf-based flag lookback rejected any title that
+    // string-equaled a --prefix/--series/--template value.
+    const result = spawnSync(["bun", SCRIPT_PATH, "--prefix", "weekly", "weekly"]);
+    expect(result.exitCode).toBe(0);
+
+    const date = new Date().toISOString().split("T")[0];
+    const filePath = path.join(CONTENT_DIR, `${date}-weekly-weekly.mdx`);
+    expect(fs.existsSync(filePath)).toBe(true);
+    createdFiles.push(filePath);
+  });
+
+  test("keeps $-patterns in titles literal", () => {
+    // Regression: a string replace() treated $& / $' in the title as
+    // back-references and corrupted the frontmatter.
+    const title = "Cash $& Money";
+    const result = spawnSync(["bun", SCRIPT_PATH, title]);
+    expect(result.exitCode).toBe(0);
+
+    const date = new Date().toISOString().split("T")[0];
+    const filePath = path.join(CONTENT_DIR, `${date}-${slugifyAscii(title)}.mdx`);
+    expect(fs.existsSync(filePath)).toBe(true);
+    createdFiles.push(filePath);
+
+    expect(matter(fs.readFileSync(filePath, "utf-8")).data.title).toBe(title);
+  });
+
+  test("escapes double quotes in titles so the frontmatter stays valid YAML", () => {
+    const title = 'The "Best" Post';
+    const result = spawnSync(["bun", SCRIPT_PATH, title]);
+    expect(result.exitCode).toBe(0);
+
+    const date = new Date().toISOString().split("T")[0];
+    const filePath = path.join(CONTENT_DIR, `${date}-${slugifyAscii(title)}.mdx`);
+    expect(fs.existsSync(filePath)).toBe(true);
+    createdFiles.push(filePath);
+
+    expect(matter(fs.readFileSync(filePath, "utf-8")).data.title).toBe(title);
   });
 
   test("should create a folder post", () => {


### PR DESCRIPTION
## Summary

A full-codebase review (content layer, rendering pipeline, routes/components, scripts/config/tests) surfaced ~29 verified findings. This PR fixes the two highest-value tiers in 12 focused commits: 8 confirmed bugs and 4 strict-build consistency gaps, each with tests where the seam is testable.

## Confirmed bugs

- **Excerpts leaked raw link syntax** — `generateExcerpt`'s link-stripping regex required the impossible shape `*[text*](url)`, so `[text](url)` + the URL flowed into every derived meta description, RSS/Atom item, JSON-LD, and OG description. The emphasis pass matched a nonsense `\$\*\*` literal.
- **Phantom TOC entries** — `getHeadings` scanned fenced code blocks, so `## foo` inside a fence produced dead TOC anchors and desynced dedup ids (`setup-1` vs rendered `setup`).
- **Flow tag filter returned zero results for mixed-case tags** — lowercased sidebar keys compared against raw-case item tags.
- **Flow calendar hydration mismatch** — initial month + today-ring came from `new Date()` in the render body (build-time month baked into the prerender); the ring also used UTC `toISOString()`, marking the wrong day off-UTC. Now content-derived on SSR, with today read via `useSyncExternalStore` (null server snapshot).
- **Tags route could crash the export** — bare `decodeURIComponent` throws `URIError` on a tag containing a stray `%`; now on the `safeDecodeParam`/`resolveFromParam` ladder with dev encoded variants, like every other dynamic route.
- **Wikilink HTML injection** — `[[x|<img onerror=…>]]` display text and slugs were interpolated unescaped into raw `html` nodes that pass through `rehypeRaw`.
- **URL hygiene** — `//` post URLs in ShareBar + split giscus/disqus threads when `baseUrl` has a trailing slash; paginated-series alias canonical missing its trailing slash (301 hop for crawlers).
- **Content-script bugs** — `new-post.ts` rejected any title equal to a flag value (`bun run new-weekly weekly` failed); template fill corrupted `$&`/`$'` titles via `replace()` back-references; four scripts wrote unescaped quotes into double-quoted YAML frontmatter. Shared `yamlDoubleQuoted` helper + regression tests with special-character titles.
- Two `fs.readFileSync` calls in the rST renderer were missing the required `turbopackIgnore` annotation.

## Strict-build consistency

- **Manual series orders and collection items now throw on unresolved slugs** instead of silently dropping the post (matching the books missing-chapter precedent). Draft/future posts still skip silently — distinguishing the two needed a pre-publication-filter view, exposed as `getAllPostsIncludingUnpublished()`.
- **Slug registry collision checks for posts and flows** — posts throw on canonical-**URL** collisions (bare-slug duplicates across series are legal by design: autoPaths gives them distinct URLs, and the rST toctree fixtures rely on it); flows throw on duplicate date slugs (`DD.md` next to `DD/index.md`).
- **Draft book chapters are pruned from `chapters`/TOC/prev-next in production** — `getBookChapter` 404s them, so published neighbors rendered dead links. A chapter with broken frontmatter is deliberately NOT treated as draft and still fails the build loudly.
- **Full-content feeds** — rST posts now use their real `renderedHtml` instead of being mangled through the Markdown parser, and relative/site-relative `src`/`href` are absolutized against the item URL (feed readers resolve nothing).

## Tests

New/extended coverage: text-metrics link/fence cases, wikilink escaping, special-character script titles, `tests/integration/series-strict-resolution.test.ts`, registry flow-collision fixture, draft-chapter production behavior, and feed absolute-URL/rST assertions. Verified with `bun run lint && bun run test` (523 unit/tooling + 307 integration + 34 dom passing).

## Review findings deferred (not in this PR)

Highest value first: CI installs no docutils, so the Python rST renderer (~900 lines) has zero CI coverage and CI builds silently use the JS fallback; vacuous draft-series test + e2e specs that pass with zero assertions when no server is up; sitemap omits series/tags/authors/notes; unused `search.json` route; `create-amytis` never published by CI; root package has no `files` field (content/tests ship in the npm tarball).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of titles with quotes and special characters when generating post/notes/series content and embedded-frontmatter for images/PDF.
  * Fixed tag page resolution (better decoding, consistent canonical display, accurate counts) and case-insensitive tag filtering.
  * Corrected Flow calendar “today” and month rendering to avoid hydration day mismatches.
  * Improved feed link rendering (absolute URLs) and improved wikilink safety; excerpt/heading parsing now ignores fenced code blocks.
* **Content Validation**
  * Build now fails on conflicting URLs and invalid/missing series/collection references; strict series/collection resolution is enforced.
* **Accessibility & Compatibility**
  * Production navigation and TOCs now exclude draft book chapters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->