### PR TITLE
fix: full-content feed fidelity — render extended syntax, sanitize rST, clean excerpts

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -160,6 +160,14 @@ types → io/cache → series-metadata → parse → posts → series → {relat
 - `discovery.ts` — cross-content aggregates: `getAllTags`, `buildSlugRegistry` (wikilink targets), `getBacklinks`.
 - Text metrics: `src/lib/text-metrics.ts` owns reading-time, word-count, excerpt, and heading extraction for **all** formats. The Markdown pipeline, the JS rST fallback (`rst.ts`), and the Python rST renderer (`rst-renderer.ts`, via the `…FromText` plain-text variants) share its tokenizer and pacing constants, so the metrics can never disagree across pipelines.
 
+## Feeds
+
+All eight feed routes are thin wrappers over `src/lib/feed-utils.ts` (`generateRssFeed` / `generateAtomFeed` / `getFeedItems`). With `feed.content: 'full'`:
+
+- Markdown/MDX items render through `src/lib/markdown-to-html.ts` — the same author-facing syntax set as `MarkdownRenderer` (GFM, GitHub alerts, VuePress containers, code groups, wikilinks, math) as a plain HTML string. Feed-specific choices: synthetic `<github-alert>`/`<code-group>` elements are rewritten to titled blockquotes / labeled `<pre>` blocks, KaTeX emits MathML-only output (readers never load the KaTeX stylesheet), and Shiki / `rehype-slug` / `rehype-image-metadata` are deliberately skipped (page-only concerns). If `MarkdownRenderer` gains a syntax plugin, add it here too — `tests/integration/feed-utils.test.ts` asserts the known syntaxes don't leak as literal text.
+- rST items embed their docutils `renderedHtml`, sanitized by the same shared allowlist the on-page renderer uses (`src/lib/rst-sanitize.ts`); when docutils didn't run, the item falls back to the plain-text excerpt rather than mis-parsing rST source as Markdown.
+- Sorting and the `maxItems` cut happen before content rendering, so only surviving items pay the render cost. All relative URLs are absolutized against the item's page URL.
+
 ## Code Block Highlighting
 
 - Highlighter: **Shiki** (build-time, dual `github-light` / `github-dark` theme via CSS variables). See `docs/CODE-BLOCKS.md` for author-facing fence/directive metadata.

--- a/src/components/RstRenderer.tsx
+++ b/src/components/RstRenderer.tsx
@@ -4,7 +4,7 @@ import dynamic from 'next/dynamic';
 import type { SlugRegistryEntry } from '@/lib/content/discovery';
 import { rstToMarkdown } from '@/lib/rst';
 import { applyShikiToRstHtml } from '@/lib/shiki-rst';
-import sanitizeHtml from 'sanitize-html';
+import { sanitizeRenderedRstHtml } from '@/lib/rst-sanitize';
 
 // Dynamic so katex.min.css gets its own chunk — see KatexStyles.tsx.
 const KatexStyles = dynamic(() => import('@/components/KatexStyles'));
@@ -17,112 +17,12 @@ interface RstRendererProps {
   slugRegistry?: Map<string, SlugRegistryEntry>;
 }
 
-const allowedTags = [
-  ...(sanitizeHtml.defaults.allowedTags ?? []),
-  'section',
-  'img',
-  'source',
-  'figure',
-  'figcaption',
-  'aside',
-  // Tabbed code groups (CSS-only via radio + label). Without these on the
-  // allowlist, the rST path drops to stacked code blocks with no tabs.
-  // transformTags below restricts `input` to type="radio" only.
-  'input',
-  'label',
-  'math',
-  'annotation',
-  'annotation-xml',
-  'maction',
-  'menclose',
-  'merror',
-  'mfenced',
-  'mfrac',
-  'mi',
-  'mmultiscripts',
-  'mn',
-  'mo',
-  'mover',
-  'mpadded',
-  'mphantom',
-  'mprescripts',
-  'mroot',
-  'mrow',
-  'ms',
-  'mspace',
-  'msqrt',
-  'mstyle',
-  'msub',
-  'msubsup',
-  'msup',
-  'mtable',
-  'mtd',
-  'mtext',
-  'mtr',
-  'munder',
-  'munderover',
-  'semantics',
-];
-
-// Shiki emits inline `style="--shiki-light:#...; --shiki-dark:#..."` CSS vars on
-// every token <span> when running in dual-theme mode, plus our custom transformers
-// add `data-language`, `data-line-numbers`, `data-highlighted-line`, and `data-title`
-// to <pre>/<span>. Stripping any of these silently kills syntax highlighting in rST
-// output while leaving Markdown unaffected — covered by RstRenderer.test.tsx.
-const codeBlockAttrs = ['style', 'data-language', 'data-line', 'data-line-numbers', 'data-highlighted-line', 'data-title', 'tabindex'];
-
-const allowedAttributes: sanitizeHtml.IOptions['allowedAttributes'] = {
-  ...sanitizeHtml.defaults.allowedAttributes,
-  '*': ['id', 'class', 'title', 'lang', 'dir', 'role', 'aria-label', 'aria-hidden'],
-  a: ['href', 'name', 'target', 'rel', 'id', 'class', 'title'],
-  img: ['src', 'srcset', 'alt', 'title', 'width', 'height', 'loading', 'decoding', 'class', 'id'],
-  source: ['src', 'srcset', 'type'],
-  td: ['colspan', 'rowspan', 'align'],
-  th: ['colspan', 'rowspan', 'align', 'scope'],
-  ol: ['start', 'reversed', 'type'],
-  li: ['value'],
-  math: ['display', 'xmlns'],
-  annotation: ['encoding'],
-  'annotation-xml': ['encoding'],
-  pre: ['class', 'style', ...codeBlockAttrs],
-  code: ['class', 'style', ...codeBlockAttrs],
-  span: ['class', 'style', ...codeBlockAttrs],
-  div: ['class', 'style', 'data-group-id', 'data-panel', ...codeBlockAttrs],
-  // Tabbed code groups: input is restricted to type=radio via transformTags.
-  // Defense-in-depth: even if an unexpected attr slips in, the CSS-only tab
-  // mechanism can't do anything dangerous with a stray radio button.
-  input: ['type', 'name', 'id', 'checked', 'data-idx', 'aria-controls', 'tabindex', 'class'],
-  label: ['for', 'class', 'role', 'aria-controls', 'tabindex', 'data-cg-icon'],
-};
-
-function sanitizeRenderedHtml(html: string): string {
-  return sanitizeHtml(html, {
-    allowedTags,
-    allowedAttributes,
-    allowedSchemes: ['http', 'https', 'mailto'],
-    allowedSchemesByTag: {
-      img: ['http', 'https'],
-    },
-    allowProtocolRelative: false,
-    transformTags: {
-      // Restrict <input> to type="radio" only. Anything else gets stripped.
-      // Prevents an rST author from injecting password/file/etc. inputs.
-      input: (tagName, attribs) => {
-        if (attribs.type !== 'radio') {
-          return { tagName: 'span', attribs: {} };
-        }
-        return { tagName, attribs };
-      },
-    },
-  });
-}
-
 export default async function RstRenderer({ content, html, latex = false, slug, slugRegistry }: RstRendererProps) {
   if (html) {
     // The docutils pass emits opaque <pre data-amytis-code> markers; run them through
     // Shiki here (server-side, build-time for SSG) before sanitizing.
     const highlighted = await applyShikiToRstHtml(html);
-    const sanitizedHtml = sanitizeRenderedHtml(highlighted).replace(
+    const sanitizedHtml = sanitizeRenderedRstHtml(highlighted).replace(
       /<table\b([^>]*)>/g,
       '<div class="rst-table-wrapper"><table$1>'
     ).replace(/<\/table>/g, '</table></div>');

--- a/src/lib/feed-utils.ts
+++ b/src/lib/feed-utils.ts
@@ -5,6 +5,7 @@ import { siteConfig } from '../../site.config';
 import { getPostUrl, getFlowUrl, withTrailingSlash } from './urls';
 import { resolveLocale } from './i18n';
 import { markdownToHtml } from './markdown-to-html';
+import { sanitizeRenderedRstHtml } from './rst-sanitize';
 
 export interface FeedItem {
   title: string;
@@ -36,25 +37,37 @@ function absolutizeHtmlUrls(html: string, pageUrl: string): string {
 /** The fields the feed needs from a post or flow to render full content. */
 interface FeedContentSource {
   content: string;
+  excerpt: string;
   renderedHtml?: string;
   sourceFormat?: 'markdown' | 'rst';
   latex?: boolean;
 }
 
+const escapeHtmlText = (v: string) =>
+  v.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+
 /**
  * Item HTML for content:encoded / Atom <content>. rST posts carry their real
- * HTML in renderedHtml — running the rST source through a Markdown parser
- * mangles directives into literal text — and Markdown posts go through the
- * shared full-syntax pipeline (alerts, containers, wikilinks, math).
+ * HTML in renderedHtml, sanitized with the same allowlist the on-page
+ * RstRenderer applies; when the docutils renderer didn't run (renderedHtml
+ * unset) fall back to the plain-text excerpt — running rST source through a
+ * Markdown parser mangles directives into literal text. Markdown posts go
+ * through the shared full-syntax pipeline (alerts, containers, wikilinks,
+ * math).
  */
 function itemContentHtml(
   post: FeedContentSource,
   pageUrl: string,
   slugRegistry: Map<string, SlugRegistryEntry>,
 ): string {
-  const html = post.sourceFormat === 'rst' && post.renderedHtml
-    ? post.renderedHtml
-    : markdownToHtml(post.content, { slugRegistry, math: post.latex });
+  let html: string;
+  if (post.sourceFormat === 'rst') {
+    html = post.renderedHtml
+      ? sanitizeRenderedRstHtml(post.renderedHtml)
+      : `<p>${escapeHtmlText(post.excerpt)}</p>`;
+  } else {
+    html = markdownToHtml(post.content, { slugRegistry, math: post.latex });
+  }
   return absolutizeHtmlUrls(html, pageUrl);
 }
 

--- a/src/lib/feed-utils.ts
+++ b/src/lib/feed-utils.ts
@@ -1,14 +1,10 @@
-import { unified } from 'unified';
-import remarkParse from 'remark-parse';
-import remarkGfm from 'remark-gfm';
-import remarkRehype from 'remark-rehype';
-import rehypeRaw from 'rehype-raw';
-import rehypeStringify from 'rehype-stringify';
 import { getAllPosts } from './content/posts';
 import { getAllFlows } from './content/flows';
+import { buildSlugRegistry, type SlugRegistryEntry } from './content/discovery';
 import { siteConfig } from '../../site.config';
 import { getPostUrl, getFlowUrl, withTrailingSlash } from './urls';
 import { resolveLocale } from './i18n';
+import { markdownToHtml } from './markdown-to-html';
 
 export interface FeedItem {
   title: string;
@@ -19,17 +15,6 @@ export interface FeedItem {
   content: string;
   tags: string[];
   authors?: string[];
-}
-
-function markdownToHtml(markdown: string): string {
-  const result = unified()
-    .use(remarkParse)
-    .use(remarkGfm)
-    .use(remarkRehype, { allowDangerousHtml: true })
-    .use(rehypeRaw)
-    .use(rehypeStringify)
-    .processSync(markdown);
-  return String(result);
 }
 
 /**
@@ -48,19 +33,28 @@ function absolutizeHtmlUrls(html: string, pageUrl: string): string {
   });
 }
 
+/** The fields the feed needs from a post or flow to render full content. */
+interface FeedContentSource {
+  content: string;
+  renderedHtml?: string;
+  sourceFormat?: 'markdown' | 'rst';
+  latex?: boolean;
+}
+
 /**
  * Item HTML for content:encoded / Atom <content>. rST posts carry their real
  * HTML in renderedHtml — running the rST source through a Markdown parser
  * mangles directives into literal text — and Markdown posts go through the
- * plain GFM pipeline.
+ * shared full-syntax pipeline (alerts, containers, wikilinks, math).
  */
 function itemContentHtml(
-  post: { content: string; renderedHtml?: string; sourceFormat?: 'markdown' | 'rst' },
+  post: FeedContentSource,
   pageUrl: string,
+  slugRegistry: Map<string, SlugRegistryEntry>,
 ): string {
   const html = post.sourceFormat === 'rst' && post.renderedHtml
     ? post.renderedHtml
-    : markdownToHtml(post.content);
+    : markdownToHtml(post.content, { slugRegistry, math: post.latex });
   return absolutizeHtmlUrls(html, pageUrl);
 }
 
@@ -77,48 +71,70 @@ export function getFeedItems(feedType: FeedType = 'main', includeFullContent: bo
   const { maxItems, includeFlows } = siteConfig.feed;
   const baseUrl = siteConfig.baseUrl.replace(/\/+$/, '');
 
-  let items: FeedItem[] = [];
+  // Full-content HTML rendering is the expensive part, so sort and apply the
+  // maxItems cut on lightweight entries first and only render the survivors.
+  interface FeedEntry {
+    item: FeedItem;
+    source: FeedContentSource;
+  }
 
-  const getPostItems = () => getAllPosts().map((post) => {
+  const getPostEntries = (): FeedEntry[] => getAllPosts().map((post) => {
     const url = withTrailingSlash(`${baseUrl}${getPostUrl(post)}`);
     return {
-      title: post.title,
-      url,
-      date: new Date(post.date),
-      excerpt: post.excerpt,
-      content: includeFullContent ? itemContentHtml(post, url) : '',
-      tags: post.tags || [],
-      authors: post.authors,
+      item: {
+        title: post.title,
+        url,
+        date: new Date(post.date),
+        excerpt: post.excerpt,
+        content: '',
+        tags: post.tags || [],
+        authors: post.authors,
+      },
+      source: post,
     };
   });
 
-  const getFlowItems = () => getAllFlows().map((flow) => {
+  const getFlowEntries = (): FeedEntry[] => getAllFlows().map((flow) => {
     const url = withTrailingSlash(`${baseUrl}${getFlowUrl(flow.slug)}`);
     return {
-      title: flow.title,
-      url,
-      date: new Date(flow.date),
-      excerpt: flow.excerpt,
-      content: includeFullContent ? itemContentHtml(flow, url) : '',
-      tags: flow.tags || [],
+      item: {
+        title: flow.title,
+        url,
+        date: new Date(flow.date),
+        excerpt: flow.excerpt,
+        content: '',
+        tags: flow.tags || [],
+      },
+      source: flow,
     };
   });
 
+  let entries: FeedEntry[];
   if (feedType === 'posts') {
-    items = getPostItems();
+    entries = getPostEntries();
   } else if (feedType === 'flows') {
-    items = getFlowItems();
+    entries = getFlowEntries();
   } else if (feedType === 'all') {
-    items = [...getPostItems(), ...getFlowItems()];
+    entries = [...getPostEntries(), ...getFlowEntries()];
   } else {
     // main
-    items = includeFlows ? [...getPostItems(), ...getFlowItems()] : getPostItems();
+    entries = includeFlows ? [...getPostEntries(), ...getFlowEntries()] : getPostEntries();
   }
 
   // Sort descending by date
-  items.sort((a, b) => b.date.getTime() - a.date.getTime());
+  entries.sort((a, b) => b.item.date.getTime() - a.item.date.getTime());
 
-  return maxItems > 0 ? items.slice(0, maxItems) : items;
+  const kept = maxItems > 0 ? entries.slice(0, maxItems) : entries;
+
+  if (!includeFullContent) {
+    return kept.map(({ item }) => item);
+  }
+
+  const slugRegistry = buildSlugRegistry();
+  return kept.map(({ item, source }) => ({
+    ...item,
+    content: itemContentHtml(source, item.url, slugRegistry),
+  }));
 }
 
 const escapeXml = (v: string) =>

--- a/src/lib/markdown-to-html.ts
+++ b/src/lib/markdown-to-html.ts
@@ -1,0 +1,146 @@
+import { unified } from 'unified';
+import remarkParse from 'remark-parse';
+import remarkGfm from 'remark-gfm';
+import remarkDirective from 'remark-directive';
+import remarkMath from 'remark-math';
+import remarkRehype from 'remark-rehype';
+import rehypeRaw from 'rehype-raw';
+import rehypeKatex from 'rehype-katex';
+import rehypeStringify from 'rehype-stringify';
+import { visit } from 'unist-util-visit';
+import type { Root, Element, ElementContent } from 'hast';
+import remarkGithubAlerts from './remark-github-alerts';
+import remarkCodeGroup from './remark-code-group';
+import remarkVuepressContainers, { normalizeVuepressContainerSyntax } from './remark-vuepress-containers';
+import remarkWikilinks from './remark-wikilinks';
+import { normalizeVuepressBlockMath } from './normalize-vuepress-math';
+import type { SlugRegistryEntry } from './content/discovery';
+
+export interface MarkdownToHtmlOptions {
+  /** Resolve `[[wikilinks]]` against this registry; leave unset to pass them through. */
+  slugRegistry?: Map<string, SlugRegistryEntry>;
+  /**
+   * Parse `$...$` / `$$...$$` as math. Gate on the post's `latex` flag exactly
+   * like the on-page renderer — enabling it unconditionally would mangle
+   * ordinary dollar amounts in non-math posts.
+   */
+  math?: boolean;
+}
+
+const ALERT_TITLES: Record<string, string> = {
+  note: 'Note',
+  tip: 'Tip',
+  important: 'Important',
+  warning: 'Warning',
+  caution: 'Caution',
+};
+
+/**
+ * The properties key depends on whether the element survived a rehype-raw
+ * round trip: hProperties keys stay verbatim (`data-alert-type`), while
+ * parse5 re-parsing camelizes them (`dataAlertType`).
+ */
+function getDataProp(node: Element, kebab: string, camel: string): string | undefined {
+  const value = node.properties?.[kebab] ?? node.properties?.[camel];
+  return value == null ? undefined : String(value);
+}
+
+function labeledParagraph(label: string): ElementContent {
+  return {
+    type: 'element',
+    tagName: 'p',
+    properties: {},
+    children: [
+      { type: 'element', tagName: 'strong', properties: {}, children: [{ type: 'text', value: label }] },
+    ],
+  };
+}
+
+/**
+ * The site pipeline emits synthetic `<github-alert>` / `<code-group>` elements
+ * that only exist as React component overrides. Feed readers know neither, so
+ * rewrite them into plain semantic HTML: alerts become a blockquote with a
+ * bold title line, code groups become sequential label + <pre> pairs.
+ */
+function rehypePlainComponents() {
+  return (tree: Root) => {
+    visit(tree, 'element', (node: Element) => {
+      if (node.tagName === 'github-alert') {
+        const type = (getDataProp(node, 'data-alert-type', 'dataAlertType') ?? 'note').toLowerCase();
+        const title = getDataProp(node, 'data-alert-title', 'dataAlertTitle') || ALERT_TITLES[type] || 'Note';
+        node.tagName = 'blockquote';
+        node.properties = {};
+        node.children = [labeledParagraph(title), ...node.children];
+      } else if (node.tagName === 'code-group') {
+        let labels: string[] = [];
+        try {
+          const parsed = JSON.parse(getDataProp(node, 'data-labels', 'dataLabels') ?? '[]');
+          labels = Array.isArray(parsed) ? parsed.map(String) : [];
+        } catch {
+          labels = [];
+        }
+        const children: ElementContent[] = [];
+        let tabIndex = 0;
+        for (const child of node.children) {
+          if (child.type === 'element' && child.tagName === 'pre') {
+            const label = labels[tabIndex];
+            tabIndex += 1;
+            if (label) children.push(labeledParagraph(label));
+          }
+          children.push(child);
+        }
+        node.tagName = 'div';
+        node.properties = {};
+        node.children = children;
+      }
+    });
+  };
+}
+
+/**
+ * Build-time markdown → HTML string for non-React surfaces (feeds). Runs the
+ * same author-facing syntax set as `MarkdownRenderer` — GFM, GitHub alerts,
+ * VuePress containers, code groups, wikilinks, math — so extended syntax
+ * renders instead of leaking as literal text. Deliberately skipped: Shiki
+ * (readers don't load our CSS; plain <pre><code> is correct), rehype-slug
+ * (heading anchors are meaningless in a feed), and rehype-image-metadata
+ * (dimension probing and CDN rewriting serve the on-page <Image> pipeline).
+ *
+ * Math renders through KaTeX with MathML-only output: readers never load the
+ * KaTeX stylesheet, and bare MathML renders natively in modern engines.
+ */
+export function markdownToHtml(markdown: string, options: MarkdownToHtmlOptions = {}): string {
+  const { slugRegistry, math = false } = options;
+
+  const source = math
+    ? normalizeVuepressBlockMath(normalizeVuepressContainerSyntax(markdown))
+    : normalizeVuepressContainerSyntax(markdown);
+
+  const processor = unified()
+    .use(remarkParse)
+    .use(remarkGfm)
+    .use(remarkGithubAlerts)
+    .use(remarkDirective)
+    .use(remarkCodeGroup)
+    .use(remarkVuepressContainers);
+  if (slugRegistry && slugRegistry.size > 0) {
+    processor.use(remarkWikilinks, { slugRegistry });
+  }
+  if (math) {
+    processor.use(remarkMath);
+  }
+  processor
+    .use(remarkRehype, { allowDangerousHtml: true })
+    .use(rehypeRaw)
+    .use(rehypePlainComponents);
+  if (math) {
+    processor.use(rehypeKatex, {
+      output: 'mathml',
+      // Mirror MarkdownRenderer: CJK text in math mode is fine, everything
+      // else KaTeX complains about is still worth a warning.
+      strict: (code: string) => (code === 'unicodeTextInMathMode' ? 'ignore' : 'warn'),
+    });
+  }
+
+  return String(processor.use(rehypeStringify).processSync(source));
+}

--- a/src/lib/rst-sanitize.ts
+++ b/src/lib/rst-sanitize.ts
@@ -13,9 +13,11 @@ const allowedTags = [
   // transformTags below restricts `input` to type="radio" only.
   'input',
   'label',
+  // MathML (KaTeX output). Deliberately NOT annotation-xml: with a free-form
+  // encoding attribute it is a known mXSS surface, and nothing we render
+  // emits it (KaTeX uses <annotation encoding="application/x-tex">).
   'math',
   'annotation',
-  'annotation-xml',
   'maction',
   'menclose',
   'merror',
@@ -66,7 +68,6 @@ const allowedAttributes: sanitizeHtml.IOptions['allowedAttributes'] = {
   li: ['value'],
   math: ['display', 'xmlns'],
   annotation: ['encoding'],
-  'annotation-xml': ['encoding'],
   pre: ['class', 'style', ...codeBlockAttrs],
   code: ['class', 'style', ...codeBlockAttrs],
   span: ['class', 'style', ...codeBlockAttrs],

--- a/src/lib/rst-sanitize.ts
+++ b/src/lib/rst-sanitize.ts
@@ -1,0 +1,107 @@
+import sanitizeHtml from 'sanitize-html';
+
+const allowedTags = [
+  ...(sanitizeHtml.defaults.allowedTags ?? []),
+  'section',
+  'img',
+  'source',
+  'figure',
+  'figcaption',
+  'aside',
+  // Tabbed code groups (CSS-only via radio + label). Without these on the
+  // allowlist, the rST path drops to stacked code blocks with no tabs.
+  // transformTags below restricts `input` to type="radio" only.
+  'input',
+  'label',
+  'math',
+  'annotation',
+  'annotation-xml',
+  'maction',
+  'menclose',
+  'merror',
+  'mfenced',
+  'mfrac',
+  'mi',
+  'mmultiscripts',
+  'mn',
+  'mo',
+  'mover',
+  'mpadded',
+  'mphantom',
+  'mprescripts',
+  'mroot',
+  'mrow',
+  'ms',
+  'mspace',
+  'msqrt',
+  'mstyle',
+  'msub',
+  'msubsup',
+  'msup',
+  'mtable',
+  'mtd',
+  'mtext',
+  'mtr',
+  'munder',
+  'munderover',
+  'semantics',
+];
+
+// Shiki emits inline `style="--shiki-light:#...; --shiki-dark:#..."` CSS vars on
+// every token <span> when running in dual-theme mode, plus our custom transformers
+// add `data-language`, `data-line-numbers`, `data-highlighted-line`, and `data-title`
+// to <pre>/<span>. Stripping any of these silently kills syntax highlighting in rST
+// output while leaving Markdown unaffected — covered by RstRenderer.test.tsx.
+const codeBlockAttrs = ['style', 'data-language', 'data-line', 'data-line-numbers', 'data-highlighted-line', 'data-title', 'tabindex'];
+
+const allowedAttributes: sanitizeHtml.IOptions['allowedAttributes'] = {
+  ...sanitizeHtml.defaults.allowedAttributes,
+  '*': ['id', 'class', 'title', 'lang', 'dir', 'role', 'aria-label', 'aria-hidden'],
+  a: ['href', 'name', 'target', 'rel', 'id', 'class', 'title'],
+  img: ['src', 'srcset', 'alt', 'title', 'width', 'height', 'loading', 'decoding', 'class', 'id'],
+  source: ['src', 'srcset', 'type'],
+  td: ['colspan', 'rowspan', 'align'],
+  th: ['colspan', 'rowspan', 'align', 'scope'],
+  ol: ['start', 'reversed', 'type'],
+  li: ['value'],
+  math: ['display', 'xmlns'],
+  annotation: ['encoding'],
+  'annotation-xml': ['encoding'],
+  pre: ['class', 'style', ...codeBlockAttrs],
+  code: ['class', 'style', ...codeBlockAttrs],
+  span: ['class', 'style', ...codeBlockAttrs],
+  div: ['class', 'style', 'data-group-id', 'data-panel', ...codeBlockAttrs],
+  // Tabbed code groups: input is restricted to type=radio via transformTags.
+  // Defense-in-depth: even if an unexpected attr slips in, the CSS-only tab
+  // mechanism can't do anything dangerous with a stray radio button.
+  input: ['type', 'name', 'id', 'checked', 'data-idx', 'aria-controls', 'tabindex', 'class'],
+  label: ['for', 'class', 'role', 'aria-controls', 'tabindex', 'data-cg-icon'],
+};
+
+/**
+ * Sanitize docutils-rendered rST HTML for embedding via dangerouslySetInnerHTML
+ * (RstRenderer) or a feed's <content:encoded> (feed-utils). One shared config:
+ * the allowlist decisions above are load-bearing for Shiki output and the
+ * radio-tab code groups, and the two consumers must not drift apart.
+ */
+export function sanitizeRenderedRstHtml(html: string): string {
+  return sanitizeHtml(html, {
+    allowedTags,
+    allowedAttributes,
+    allowedSchemes: ['http', 'https', 'mailto'],
+    allowedSchemesByTag: {
+      img: ['http', 'https'],
+    },
+    allowProtocolRelative: false,
+    transformTags: {
+      // Restrict <input> to type="radio" only. Anything else gets stripped.
+      // Prevents an rST author from injecting password/file/etc. inputs.
+      input: (tagName, attribs) => {
+        if (attribs.type !== 'radio') {
+          return { tagName: 'span', attribs: {} };
+        }
+        return { tagName, attribs };
+      },
+    },
+  });
+}

--- a/src/lib/text-metrics.test.ts
+++ b/src/lib/text-metrics.test.ts
@@ -64,6 +64,10 @@ describe("text metrics", () => {
       const text = 'Before <rss-feed url="https://example.com/feed" /> and <em>after</em> text';
       expect(generateExcerpt(text)).toBe("Before and after text");
     });
+
+    test("should not leave dangling backticks when inline code wraps a tag", () => {
+      expect(generateExcerpt("Use `<br>` here")).toBe("Use here");
+    });
   });
 
   describe("calculateReadingMinutes", () => {

--- a/src/lib/text-metrics.test.ts
+++ b/src/lib/text-metrics.test.ts
@@ -44,6 +44,26 @@ describe("text metrics", () => {
       expect(result).toBe("See the docs for details");
       expect(result).not.toContain("https://");
     });
+
+    test("should keep wikilink display text or slug", () => {
+      const text = "See [[my-note|the note]] and [[another-note]] for context";
+      expect(generateExcerpt(text)).toBe("See the note and another-note for context");
+    });
+
+    test("should drop ::: container marker lines", () => {
+      const text = ":::tip Some title\nThe advice itself\n:::";
+      expect(generateExcerpt(text)).toBe("The advice itself");
+    });
+
+    test("should drop GitHub alert markers but keep the alert body", () => {
+      const text = "> [!NOTE]\n> Something worth knowing";
+      expect(generateExcerpt(text)).toBe("Something worth knowing");
+    });
+
+    test("should strip raw HTML and custom-element tags", () => {
+      const text = 'Before <rss-feed url="https://example.com/feed" /> and <em>after</em> text';
+      expect(generateExcerpt(text)).toBe("Before and after text");
+    });
   });
 
   describe("calculateReadingMinutes", () => {

--- a/src/lib/text-metrics.ts
+++ b/src/lib/text-metrics.ts
@@ -102,12 +102,14 @@ export function generateExcerpt(content: string): string {
   // Wikilinks: keep the display text ([[slug|display]]) or the slug ([[slug]]).
   plain = plain.replace(/\[\[([^\]|]+?)\|([^\]]+?)\]\]/g, '$2');
   plain = plain.replace(/\[\[([^\]]+?)\]\]/g, '$1');
+  // Unwrap inline code BEFORE stripping tags: `<br>` must not become a
+  // dangling backtick pair once the tag inside it is deleted.
+  plain = plain.replace(/`([^`]+)`/g, '$1');
   // Raw HTML/JSX tags (custom elements like <rss-feed …/> included).
   plain = plain.replace(/<\/?[a-zA-Z][^>]*>/g, '');
   plain = plain.replace(/!\[[^\]]*\]\([^)]+\)/g, '');
   plain = plain.replace(/\[([^\]]+)\]\([^)]+\)/g, '$1');
   plain = plain.replace(/(\*\*|__|\*|_)/g, '');
-  plain = plain.replace(/`([^`]+)`/g, '$1');
   plain = plain.replace(/^>\s+/gm, '');
   // GitHub alert markers survive the blockquote strip above ("> [!NOTE]").
   plain = plain.replace(/\[!(?:NOTE|TIP|IMPORTANT|WARNING|CAUTION)\][ \t]*/gi, '');

--- a/src/lib/text-metrics.ts
+++ b/src/lib/text-metrics.ts
@@ -96,11 +96,21 @@ export function calculateWordCountFromText(text: string): number {
 export function generateExcerpt(content: string): string {
   let plain = content.replace(/^#+\s+/gm, '');
   plain = plain.replace(FENCED_CODE_BLOCK_RE, '');
+  // ::: container opener/closer lines (VuePress/directive syntax) are pure
+  // markup; after fence removal any remaining ones are prose-level.
+  plain = plain.replace(/^:{3,}[^\n]*$/gm, '');
+  // Wikilinks: keep the display text ([[slug|display]]) or the slug ([[slug]]).
+  plain = plain.replace(/\[\[([^\]|]+?)\|([^\]]+?)\]\]/g, '$2');
+  plain = plain.replace(/\[\[([^\]]+?)\]\]/g, '$1');
+  // Raw HTML/JSX tags (custom elements like <rss-feed …/> included).
+  plain = plain.replace(/<\/?[a-zA-Z][^>]*>/g, '');
   plain = plain.replace(/!\[[^\]]*\]\([^)]+\)/g, '');
   plain = plain.replace(/\[([^\]]+)\]\([^)]+\)/g, '$1');
   plain = plain.replace(/(\*\*|__|\*|_)/g, '');
   plain = plain.replace(/`([^`]+)`/g, '$1');
   plain = plain.replace(/^>\s+/gm, '');
+  // GitHub alert markers survive the blockquote strip above ("> [!NOTE]").
+  plain = plain.replace(/\[!(?:NOTE|TIP|IMPORTANT|WARNING|CAUTION)\][ \t]*/gi, '');
   plain = plain.replace(/\s+/g, ' ').trim();
 
   if (plain.length <= 160) {

--- a/tests/integration/feed-utils.test.ts
+++ b/tests/integration/feed-utils.test.ts
@@ -171,6 +171,7 @@ describe("Integration: Feed Utils", () => {
     try {
       siteConfig.feed.maxItems = 0;
       const items = getFeedItems("all", true);
+      expect(items.length).toBeGreaterThan(0);
       items.forEach((item) => {
         const prose = stripCodeIslands(item.content);
         // ::: container openers/closers must be consumed by remark-directive.

--- a/tests/integration/feed-utils.test.ts
+++ b/tests/integration/feed-utils.test.ts
@@ -137,15 +137,106 @@ describe("Integration: Feed Utils", () => {
   });
 
   test("feed item content is rendered HTML, not raw Markdown", () => {
-    const items = getFeedItems();
-    items.forEach((item) => {
-      if (item.content.trim().length === 0) return;
-      // Rendered HTML must contain at least one HTML tag
-      expect(item.content).toMatch(/<[a-z][^>]*>/i);
-      // Markdown headings should not appear outside code blocks
-      const strippedCodeBlocks = item.content.replace(/<pre[\s\S]*?<\/pre>/gi, '');
-      expect(strippedCodeBlocks).not.toMatch(/^#{1,6}\s/m);
-    });
+    const originalMaxItems = siteConfig.feed.maxItems;
+    try {
+      siteConfig.feed.maxItems = 0;
+      // Must request full content explicitly — without it every item.content
+      // is '' and the assertions below pass vacuously.
+      const items = getFeedItems("all", true);
+      expect(items.length).toBeGreaterThan(0);
+      items.forEach((item) => {
+        expect(item.content.trim().length).toBeGreaterThan(0);
+        // Rendered HTML must contain at least one HTML tag
+        expect(item.content).toMatch(/<[a-z][^>]*>/i);
+        // Markdown headings should not appear outside code blocks
+        const strippedCodeBlocks = item.content.replace(/<pre[\s\S]*?<\/pre>/gi, '');
+        expect(strippedCodeBlocks).not.toMatch(/^#{1,6}\s/m);
+      });
+    } finally {
+      siteConfig.feed.maxItems = originalMaxItems;
+    }
+  });
+
+  // The showcase fixtures document extended syntax inside code examples, so
+  // fenced blocks and inline code are stripped before asserting on prose.
+  // `<code(?![-\w])` avoids eating a stray unmapped `<code-group>` tag, which
+  // must instead fail the synthetic-tag assertion below.
+  const stripCodeIslands = (html: string) =>
+    html
+      .replace(/<pre[\s\S]*?<\/pre>/gi, '')
+      .replace(/<code(?![-\w])(?:\s[^>]*)?>[\s\S]*?<\/code>/gi, '');
+
+  test("extended syntax renders in full content instead of leaking as literal text", () => {
+    const originalMaxItems = siteConfig.feed.maxItems;
+    try {
+      siteConfig.feed.maxItems = 0;
+      const items = getFeedItems("all", true);
+      items.forEach((item) => {
+        const prose = stripCodeIslands(item.content);
+        // ::: container openers/closers must be consumed by remark-directive.
+        // Substring, not line-anchored: a leaked opener renders mid-line as
+        // <p>:::code-group</p>.
+        expect(prose).not.toContain(':::');
+        // GitHub alert markers must be transformed, not shown
+        expect(prose).not.toMatch(/\[!(NOTE|TIP|IMPORTANT|WARNING|CAUTION)\]/);
+        // Wikilinks must resolve to anchors (or broken-link spans)
+        expect(prose).not.toContain('[[');
+        // Synthetic React-only tags must be mapped to plain HTML
+        expect(item.content).not.toContain('<github-alert');
+        expect(item.content).not.toContain('<code-group');
+      });
+    } finally {
+      siteConfig.feed.maxItems = originalMaxItems;
+    }
+  });
+
+  test("alerts and code groups render as plain semantic HTML in full content", () => {
+    const originalMaxItems = siteConfig.feed.maxItems;
+    try {
+      siteConfig.feed.maxItems = 0;
+      const items = getFeedItems("posts", true);
+      const showcase = items.find((i) => i.url.includes("code-block-features-showcase"));
+      expect(showcase).toBeDefined();
+      // > [!NOTE] alerts become titled blockquotes
+      expect(showcase!.content).toContain("<blockquote");
+      // :::code-group panels survive as <pre> blocks
+      expect(showcase!.content).toContain("<pre");
+    } finally {
+      siteConfig.feed.maxItems = originalMaxItems;
+    }
+  });
+
+  test("wikilinks resolve to anchors in full-content flow items", () => {
+    const flows = getAllFlows();
+    if (!flows.some((f) => /\[\[[^\]]+\]\]/.test(f.content))) return; // skip without fixtures
+
+    const originalMaxItems = siteConfig.feed.maxItems;
+    try {
+      siteConfig.feed.maxItems = 0;
+      const items = getFeedItems("flows", true);
+      const withWikilink = items.filter((i) => i.content.includes('class="wikilink'));
+      expect(withWikilink.length).toBeGreaterThan(0);
+    } finally {
+      siteConfig.feed.maxItems = originalMaxItems;
+    }
+  });
+
+  test("math posts carry MathML in full content", () => {
+    const mathPost = getAllPosts().find((p) => p.latex && p.sourceFormat !== "rst");
+    if (!mathPost) return; // skip without fixtures
+
+    const originalMaxItems = siteConfig.feed.maxItems;
+    try {
+      siteConfig.feed.maxItems = 0;
+      const url = withTrailingSlash(siteConfig.baseUrl.replace(/\/+$/, "") + getPostUrl(mathPost));
+      const item = getFeedItems("posts", true).find((i) => i.url === url);
+      expect(item).toBeDefined();
+      expect(item!.content).toContain("<math");
+      // TeX sources must not leak as $-delimited literals outside code
+      expect(stripCodeIslands(item!.content)).not.toMatch(/\$\$/);
+    } finally {
+      siteConfig.feed.maxItems = originalMaxItems;
+    }
   });
 
   test("full-content items carry no relative src/href (feed readers resolve nothing)", () => {

--- a/tests/integration/feed-utils.test.ts
+++ b/tests/integration/feed-utils.test.ts
@@ -264,6 +264,33 @@ describe("Integration: Feed Utils", () => {
     expect(item!.content).not.toMatch(/^\.\. /m);
   });
 
+  rstFeedTest("rST feed HTML is sanitized with the RstRenderer allowlist", () => {
+    const url = withTrailingSlash(siteConfig.baseUrl.replace(/\/+$/, "") + getPostUrl(rstPostWithHtml!));
+    const item = getFeedItems("posts", true).find((i) => i.url === url);
+    expect(item).toBeDefined();
+    // The docutils pass emits <pre data-amytis-code> markers; the shared
+    // sanitizer strips that attribute (it is not on the pre allowlist), so
+    // its absence is direct evidence the sanitizer ran on the feed path.
+    expect(item!.content).not.toContain("data-amytis-code");
+    expect(item!.content).not.toContain("<script");
+  });
+
+  // Inverse environment gate of the tests above: only runs where the Python
+  // docutils renderer did NOT produce renderedHtml (e.g. no python on PATH).
+  const rstPostWithoutHtml = getAllPosts().find((p) => p.sourceFormat === "rst" && !p.renderedHtml);
+  const rstFallbackTest = rstPostWithoutHtml ? test : test.skip;
+
+  rstFallbackTest("rST posts without rendered HTML fall back to the excerpt", () => {
+    const url = withTrailingSlash(siteConfig.baseUrl.replace(/\/+$/, "") + getPostUrl(rstPostWithoutHtml!));
+    const item = getFeedItems("posts", true).find((i) => i.url === url);
+    expect(item).toBeDefined();
+    // Never the mis-parsed rST source…
+    expect(item!.content).not.toMatch(/^\.\. /m);
+    expect(item!.content).not.toContain("::");
+    // …just the plain-text excerpt as a paragraph.
+    expect(item!.content).toContain("<p>");
+  });
+
   test("feed items with authors have a non-empty authors array", () => {
     const items = getFeedItems();
     items.forEach((item) => {


### PR DESCRIPTION
## Why

The bug reported in #26 (raw markdown in `content: 'full'` feeds) was fixed back in March (f3bc8c4), but a fidelity gap remained: the feed pipeline was plain GFM while the on-page renderer runs the full plugin set, so `:::` containers, `> [!NOTE]` alerts, `[[wikilinks]]`, and $math$ leaked into `<content:encoded>` as literal text. The rST path had two of its own problems: docutils HTML was embedded unsanitized, and when docutils was unavailable the rST *source* was mis-parsed as Markdown.

## What

- **`src/lib/markdown-to-html.ts` (new)** — shared build-time markdown→HTML string pipeline running the same author-facing syntax set as `MarkdownRenderer`. Feed-appropriate choices: synthetic `<github-alert>`/`<code-group>` elements map to titled blockquotes / labeled `<pre>` blocks, KaTeX emits MathML-only output (no stylesheet dependency in readers), and Shiki / rehype-slug / rehype-image-metadata stay out.
- **`src/lib/rst-sanitize.ts` (new)** — the sanitize-html allowlist hoisted out of `RstRenderer.tsx` so the page and the feed share one config. Feeds now sanitize rST `renderedHtml`; the no-docutils fallback emits the plain-text excerpt instead of mis-parsed source.
- **`getFeedItems`** now sorts and applies the `maxItems` cut before rendering, so only surviving items pay the render cost.
- **`generateExcerpt`** strips wikilinks (keeping display text), container/alert markers, and raw HTML tags from `<description>`/`<summary>` text.
- Fixed a vacuous test that asserted rendered HTML against empty content strings; new leak assertions run against the real showcase fixtures and failed against the old pipeline (verified red→green).

## Verification

`bun run lint && bun run typecheck && bun run test` green at every commit; the branch is bisectable. New feed tests: 3 failed on the old pipeline, all pass now. rST sanitize/fallback tests carry the same environment gates as the existing rST parity tests.

Closes the residual gap behind #26.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Feed entries now support full rendered Markdown and reStructuredText content.
  * Added support for alerts, code groups, wikilinks, and optional math rendering.
  * Feed output now includes sanitized HTML, safer URLs, improved excerpts, and fallback handling.
  * Entries are sorted and limited before full content is rendered.

* **Bug Fixes**
  * Improved excerpt generation by removing unsupported markup and formatting artifacts.
  * Standardized sanitization for rendered reStructuredText content.

* **Documentation**
  * Documented feed routes and rendering behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->